### PR TITLE
코인 상세 정보 화면 - 차트 UI 구현

### DIFF
--- a/AIProject/AIProject/Data/Model/CoinInterval.swift
+++ b/AIProject/AIProject/Data/Model/CoinInterval.swift
@@ -7,11 +7,20 @@
 
 import Foundation
 
+/// 코인 차트의 기간 선택 옵션
+/// `rawValue`는 UI 표시용 문자열 (예: "1D") 이며, `Identifiable`의 `id`로도 재사용
 enum CoinInterval: String, CaseIterable, Identifiable {
+    /// 1일
     case d1 = "1D"
+    /// 1주
     case w1 = "1W"
+    /// 3개월
     case m3 = "3M"
+    /// 6개월
     case m6 = "6M"
+    /// 1년
     case y1 = "1Y"
+    
+    /// UI 및 리스트 바인딩을 위한 고유 식별자
     var id: String { rawValue }
 }

--- a/AIProject/AIProject/Data/Model/CoinInterval.swift
+++ b/AIProject/AIProject/Data/Model/CoinInterval.swift
@@ -1,0 +1,17 @@
+//
+//  CoinInterval.swift
+//  AIProject
+//
+//  Created by 강민지 on 8/1/25.
+//
+
+import Foundation
+
+enum CoinInterval: String, CaseIterable, Identifiable {
+    case d1 = "1D"
+    case w1 = "1W"
+    case m3 = "3M"
+    case m6 = "6M"
+    case y1 = "1Y"
+    var id: String { rawValue }
+}

--- a/AIProject/AIProject/Data/Model/CoinPrice.swift
+++ b/AIProject/AIProject/Data/Model/CoinPrice.swift
@@ -1,0 +1,20 @@
+//
+//  CoinPrice.swift
+//  AIProject
+//
+//  Created by 강민지 on 7/31/25.
+//
+
+import Foundation
+
+struct CoinPrice: Identifiable {
+    let date: Date          // 시점(x축)
+    let close: Double       // 종가(y축)
+    var id: TimeInterval { date.timeIntervalSinceReferenceDate }
+}
+
+struct PriceSummary {
+    let lastPrice: Double   // 마지막 가격
+    let change: Double      // 첫~끝 차이
+    let changeRate: Double  // 등락률(%)
+}

--- a/AIProject/AIProject/Data/Model/CoinPrice.swift
+++ b/AIProject/AIProject/Data/Model/CoinPrice.swift
@@ -7,14 +7,22 @@
 
 import Foundation
 
+/// 코인 가격의 한 지점(시계열) 표현
 struct CoinPrice: Identifiable {
-    let date: Date          // 시점(x축)
-    let close: Double       // 종가(y축)
+    /// 데이터 시점 (차트 x축)
+    let date: Date
+    /// 해당 시점의 종가 (차트 y축)
+    let close: Double
+    /// `date` 기반 고유 식별자
     var id: TimeInterval { date.timeIntervalSinceReferenceDate }
 }
 
+/// 차트 상단 표시에 사용하는 가격 요약 값
 struct PriceSummary {
-    let lastPrice: Double   // 마지막 가격
-    let change: Double      // 첫~끝 차이
-    let changeRate: Double  // 등락률(%)
+    /// 구간의 마지막 가격
+    let lastPrice: Double
+    /// 첫 가격 대비 절대 변화량 (마지막 ~ 첫)
+    let change: Double
+    /// 첫 가격 대비 등락률 (%)
+    let changeRate: Double
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -1,0 +1,98 @@
+//
+//  CoinChartView.swift
+//  AIProject
+//
+//  Created by 강민지 on 7/31/25.
+//
+
+import SwiftUI
+import Charts
+
+struct ChartView: View {
+    @StateObject private var viewModel = ChartViewModel()
+    @State private var selectedInterval: CoinInterval = .d1 // 현재는 1D만 사용 (나머지는 UI용)
+    @State private var selectedTab = 0
+
+    private var data: [CoinPrice] { viewModel.prices }
+    private var summary: PriceSummary? { viewModel.summary }
+
+    var body: some View {
+        let lastPoint = data.last
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+
+                // 타이틀 영역
+                HStack(spacing: 8) {
+                    Text(viewModel.name)
+                        .font(.title3).bold()
+                        .foregroundStyle(.aiCoLabel)
+
+                    Text(viewModel.symbol)
+                        .font(.footnote).bold()
+                        .padding(.horizontal, 10).padding(.vertical, 6)
+                        .foregroundStyle(.gray)
+                        .background(Capsule().fill(Color(.systemGray5)))
+                }
+
+                // 현재가 / 등락
+                if let summary {
+                    Text(summary.lastPrice, format: .currency(code: viewModel.currency))
+                        .font(.largeTitle).bold()
+                        .foregroundStyle(.aiCoLabel)
+
+                    let sign = summary.change >= 0 ? "+" : ""
+                    Text("\(sign)\(summary.change, format: .currency(code: viewModel.currency)) (\(summary.changeRate, format: .number.precision(.fractionLength(1)))%)")
+                        .font(.subheadline)
+                        .foregroundStyle(summary.change >= 0 ? .aiCoNegative : .aiCoPositive)
+                }
+
+                // 차트
+                Chart {
+                    ForEach(data) { point in
+                        LineMark(
+                            x: .value("Date", point.date),
+                            y: .value("Close", point.close)
+                        )
+                    }
+                    .interpolationMethod(.linear)
+                    .lineStyle(.init(lineWidth: 3))
+                    .foregroundStyle(.aiCoNegative)
+
+                    if let last = lastPoint {
+                        PointMark(
+                            x: .value("Date", last.date),
+                            y: .value("Close", last.close)
+                        )
+                        .symbol {
+                            ZStack {
+                                Circle().fill(.aiCoNegative.opacity(0.12)).frame(width: 36, height: 36)
+                                Circle().fill(.aiCoNegative).frame(width: 10, height: 10)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 380)
+                .chartXAxis(.hidden)
+                .chartYAxis(.hidden)
+
+                GeometryReader { proxy in
+                    SegmentedControlView(
+                        selection: $selectedTab,
+                        tabTitles: CoinInterval.allCases.map(\.rawValue),
+                        width: proxy.size.width
+                    )
+                    .frame(width: proxy.size.width, height: 44)
+                }
+                .frame(height: 44)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+        }
+        .background(.aiCoBackground)
+    }
+}
+
+#Preview {
+    ChartView()
+}

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -8,12 +8,19 @@
 import SwiftUI
 import Charts
 
+/// 코인 상세 화면의 가격 차트 뷰
+/// `ChartViewModel`이 제공하는 시계열 데이터를 라인 차트로 렌더링
 struct ChartView: View {
+    /// 헤더/차트에 바인딩되는 상태를 관리하는 ViewModel
     @StateObject private var viewModel = ChartViewModel()
-    @State private var selectedInterval: CoinInterval = .d1 // 현재는 1D만 사용 (나머지는 UI용)
+    /// 사용자 선택 기간 (현재는 1D만 표시, 나머지는 UI용)
+    @State private var selectedInterval: CoinInterval = .d1
+    /// 세그먼트 탭 선택 인덱스 (커스텀 SegmentedControlView와 바인딩)
     @State private var selectedTab = 0
 
+    /// 차트 데이터 (시계열 포인트)
     private var data: [CoinPrice] { viewModel.prices }
+    /// 헤더의 가격 요약 정보(마지막가 / 변화 / 등락률)
     private var summary: PriceSummary? { viewModel.summary }
 
     var body: some View {
@@ -22,7 +29,7 @@ struct ChartView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
 
-                // 타이틀 영역
+                // 타이틀 영역: 코인명 / 심볼
                 HStack(spacing: 8) {
                     Text(viewModel.name)
                         .font(.title3).bold()
@@ -35,7 +42,7 @@ struct ChartView: View {
                         .background(Capsule().fill(Color(.systemGray5)))
                 }
 
-                // 현재가 / 등락
+                // 상단 요약: 현재가 및 등락
                 if let summary {
                     Text(summary.lastPrice, format: .currency(code: viewModel.currency))
                         .font(.largeTitle).bold()
@@ -47,7 +54,7 @@ struct ChartView: View {
                         .foregroundStyle(summary.change >= 0 ? .aiCoNegative : .aiCoPositive)
                 }
 
-                // 차트
+                // 라인 차트: 가격 시계열 렌더링 + 마지막 포인트 하이라이트
                 Chart {
                     ForEach(data) { point in
                         LineMark(
@@ -76,6 +83,7 @@ struct ChartView: View {
                 .chartXAxis(.hidden)
                 .chartYAxis(.hidden)
 
+                // 기간 선택 탭 (UI용)
                 GeometryReader { proxy in
                     SegmentedControlView(
                         selection: $selectedTab,

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -7,19 +7,26 @@
 
 import SwiftUI
 
+/// 코인 차트 화면의 상태를 관리하는 ViewModel
 @MainActor
 final class ChartViewModel: ObservableObject {
+    /// 코인 표시 이름 (예: "비트코인")
     @Published var name: String = "비트코인"
+    /// 심볼 (예: "BTC")
     @Published var symbol: String = "BTC"
+    /// 통화 코드 (예: "USD")
     @Published var currency: String = "USD"
     
+    /// 차트에 바인딩되는 시계열 가격 데이터
     @Published var prices: [CoinPrice] = []
     
+    /// 초기 진입 시 1일(1D) 범위의 더미 시계열 데이터를 준비
     init() {
-        // 최초 진입 시 1D 구간 더미 데이터
         self.prices = Self.makeDummyPrices(hours: 24, samplingInterval: 60)
     }
     
+    /// 현재 `prices` 기준의 간단한 요약 정보
+    /// 마지막 가격, 절대 변화량, 등락률 (%)을 계산해 반환
     var summary: PriceSummary? {
         guard let first = prices.first, let last = prices.last else { return nil }
         let change = last.close - first.close
@@ -28,7 +35,13 @@ final class ChartViewModel: ObservableObject {
     }
 }
 
+// MARK: - Dummy Data Generator
 extension ChartViewModel {
+    /// 지정한 시간 범위와 샘플링 간격으로 더미 시계열 가격을 생성
+    /// - Parameters:
+    ///   - hours: 과거로부터 생성할 시간 범위 (시간 단위, 예: 24)
+    ///   - samplingInterval: 샘플 간격 (초, 예: 60 → 1분)
+    /// - Returns: 생성된 `CoinPrice` 시계열 배열
     static func makeDummyPrices(hours: Double, samplingInterval: TimeInterval) -> [CoinPrice] {
         let now = Date()
         let startDate = now.addingTimeInterval(-hours * 3600)

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  CoinChartViewModel.swift
+//  AIProject
+//
+//  Created by 강민지 on 8/1/25.
+//
+
+import SwiftUI
+
+@MainActor
+final class ChartViewModel: ObservableObject {
+    @Published var name: String = "비트코인"
+    @Published var symbol: String = "BTC"
+    @Published var currency: String = "USD"
+    
+    @Published var prices: [CoinPrice] = []
+    
+    init() {
+        // 최초 진입 시 1D 구간 더미 데이터
+        self.prices = Self.makeDummyPrices(hours: 24, samplingInterval: 60)
+    }
+    
+    var summary: PriceSummary? {
+        guard let first = prices.first, let last = prices.last else { return nil }
+        let change = last.close - first.close
+        let changeRate = first.close == 0 ? 0 : (change / first.close) * 100
+        return .init(lastPrice: last.close, change: change, changeRate: changeRate)
+    }
+}
+
+extension ChartViewModel {
+    static func makeDummyPrices(hours: Double, samplingInterval: TimeInterval) -> [CoinPrice] {
+        let now = Date()
+        let startDate = now.addingTimeInterval(-hours * 3600)
+        let sampleCount = Int((hours * 3600) / samplingInterval)
+        
+        var priceSeries: [CoinPrice] = []
+        var currentTimestamp = startDate
+        var value = 100.0
+        
+        for _ in 0..<sampleCount {
+            priceSeries.append(.init(date: currentTimestamp, close: value))
+            currentTimestamp = currentTimestamp.addingTimeInterval(samplingInterval)
+        }
+        return priceSeries
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #18 

## 📝 작업 내용

- `CoinPrice` / `PriceSummary` 모델
  - `CoinPrice`: 시점(date)별 종가(close)를 담은 차트 전용 모델
  기존의  `Coin` 모델은 정리된 코인 기본 정보를 내려주는 정적 데이터,
   `CoinPrice` 모델은 그래프를 위한 시간별 코인 가격 데이터에 초점을 두고 
 두 모델을 분리해서 사용 예정입니다.
  - `PriceSummary`: 상단에 표시할 마지막 가격, 절대 등락, 등락률 계산용 구조체
- `CoinInterval` enum
차트 기간(1D, 1W, 3M, 6M, 1Y) 선택용 옵션
- `ChartViewModel` (ObservableObject)
  - 차트용 시계열 데이터를 관리, 초기 진입 시 1일(1D) 구간 더미 데이터 생성
  - 상단 헤더 요약 데이터 제공 (추후 API 연동 시 더미 데이터 생성 로직을 네트워크 데이터로 교체 예정)
- `ChartView`
  - 하단의 기간 선택 탭은 `SegmentedControlView` 공통 View를 재사용

### 스크린샷 (선택)
<img height="400" alt="스크린샷 2025-08-01 오전 11 42 24" src="https://github.com/user-attachments/assets/7c603f24-122d-495a-9866-f34635858a62" />

## 💬 리뷰 요구사항(선택)
- "비트코인", "BTC"에 해당하는 변수명을 추천해주시면 감사하겠습니다. 
