### PR TITLE
ReportView 리팩토링: 프롬프트 간소화, fetch method 위치 이동

### DIFF
--- a/AIProject/AIProject/Core/Network/NetworkError.swift
+++ b/AIProject/AIProject/Core/Network/NetworkError.swift
@@ -15,6 +15,4 @@ enum NetworkError: Error {
     case invalidResponse
 	/// API Key가 올바르지 않습니다.
     case invalidAPIKey
-    /// data가 올바르지 않습니다.
-    case invalidData
 }

--- a/AIProject/AIProject/Core/Network/NetworkError.swift
+++ b/AIProject/AIProject/Core/Network/NetworkError.swift
@@ -15,4 +15,6 @@ enum NetworkError: Error {
     case invalidResponse
 	/// API Key가 올바르지 않습니다.
     case invalidAPIKey
+    /// data가 올바르지 않습니다.
+    case invalidData
 }

--- a/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
@@ -31,3 +31,70 @@ final class AlanAPIService {
         return alanResponseDTO
     }
 }
+
+extension AlanAPIService {
+    /// "\(coin.koreanName)" 개요를 JSON 형식으로 가져옵니다.
+    func fetchOverview(for coin: Coin) async throws -> CoinOverviewDTO {
+        let content = """
+        struct CoinOverviewDTO: Codable {
+            let symbol: String 
+            let websiteURL: String?
+            let launchDate: String
+            let description: String
+        }
+
+        \"\(coin.koreanName)\" 개요를 위 JSON 형식으로 작성 (마크다운 금지)
+        """
+        let answer = try await fetchAnswer(content: content)
+        guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
+            throw NetworkError.invalidData
+        }
+        return try JSONDecoder().decode(CoinOverviewDTO.self, from: jsonData)
+    }
+
+    /// 최근 24시간 뉴스 기반 시장 분위기와 기사 목록을 JSON 형식으로 가져옵니다.
+    func fetchTodayNews(for coin: Coin) async throws -> CoinTodayNewsDTO {
+        let content = """
+        struct CoinTodayNewsDTO: Codable {
+            let todaySentiment: String
+            let articles: [CoinArticleDTO]
+        }
+
+        struct CoinArticleDTO: Codable {
+            let title: String
+            let summary: String
+            let url: String
+        }
+
+        1. 현재 국내 시간을 기준으로 최근 24시간 뉴스 기반
+        2. 뉴스 전반을 분석해 시장 분위기를 요약
+
+        위 조건에 따라 \"\(coin.koreanName)\"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
+        """
+        let answer = try await fetchAnswer(content: content)
+        guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
+            throw NetworkError.invalidData
+        }
+        return try JSONDecoder().decode(CoinTodayNewsDTO.self, from: jsonData)
+    }
+
+    /// 일주일간의 가격 추이 및 거래량 변화 정보를 JSON 형식으로 가져옵니다.
+    func fetchWeeklyTrends(for coin: Coin) async throws -> CoinWeeklyDTO {
+        let content = """
+        struct CoinWeeklyDTO: Codable {
+            let priceTrend: String
+            let volumeChange: String
+            let reason: String
+        }
+
+        1. 현재 국내 시간을 기준으로 일주일 동안의 정보 사용
+
+        위 조건에 따라 \"\(coin.koreanName)\"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
+        """
+        let answer = try await fetchAnswer(content: content)
+        guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
+            throw NetworkError.invalidData
+        }
+        return try JSONDecoder().decode(CoinWeeklyDTO.self, from: jsonData)
+    }
+}

--- a/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
@@ -47,8 +47,14 @@ extension AlanAPIService {
         """
         let answer = try await fetchAnswer(content: content)
         guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
-            throw NetworkError.invalidData
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "extractedJSON 문자열을 UTF-8 데이터로 변환하는 데 실패했습니다."
+                )
+            )
         }
+        
         return try JSONDecoder().decode(CoinOverviewDTO.self, from: jsonData)
     }
 
@@ -73,8 +79,14 @@ extension AlanAPIService {
         """
         let answer = try await fetchAnswer(content: content)
         guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
-            throw NetworkError.invalidData
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "extractedJSON 문자열을 UTF-8 데이터로 변환하는 데 실패했습니다."
+                )
+            )
         }
+        
         return try JSONDecoder().decode(CoinTodayNewsDTO.self, from: jsonData)
     }
 
@@ -93,8 +105,14 @@ extension AlanAPIService {
         """
         let answer = try await fetchAnswer(content: content)
         guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
-            throw NetworkError.invalidData
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "extractedJSON 문자열을 UTF-8 데이터로 변환하는 데 실패했습니다."
+                )
+            )
         }
+        
         return try JSONDecoder().decode(CoinWeeklyDTO.self, from: jsonData)
     }
 }

--- a/AIProject/AIProject/Data/Response/AlanResponse/Content/CoinOverviewDTO.swift
+++ b/AIProject/AIProject/Data/Response/AlanResponse/Content/CoinOverviewDTO.swift
@@ -15,7 +15,7 @@ struct CoinOverviewDTO: Codable {
     let websiteURL: String?
     
     /// 최초발행
-    let startDate: String
+    let launchDate: String
     
     /// 디지털 자산 소개
     let description: String

--- a/AIProject/AIProject/Data/Response/AlanResponse/Content/CoinTodayNewsDTO.swift
+++ b/AIProject/AIProject/Data/Response/AlanResponse/Content/CoinTodayNewsDTO.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct CoinTodayNewsDTO: Codable {
     /// 오늘 시장 분위기
-    let today: String
+    let todaySentiment: String
     
     /// 뉴스 배열, 3개
     let articles: [CoinArticleDTO]

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -21,9 +21,9 @@ struct ReportView: View {
                 
                 ReportSectionView(title: "오늘 시장 분위기 살펴보기", contents: [viewModel.coinTodayTrends])
                 
-                ReportSectionView(title: "주간 동향 확인", contents: [viewModel.coinWeeklyTrends])
-                
                 ReportNewsSectionView(title: "주요 뉴스", articles: viewModel.coinTodayTopNews, isNews: true)
+                
+                ReportSectionView(title: "주간 동향 확인", contents: [viewModel.coinWeeklyTrends])
             }
         }
         .padding(.top, 15)

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
@@ -47,25 +47,14 @@ final class ReportViewModel: ObservableObject {
     
     private func fetchOverView() {
         let content = """
-        struct CoinOverviewDTO: Codable { // 주석은 주어진 키워드가 '이더리움'인 경우 예상 응답
-            /// 심볼: ETH
+        struct CoinOverviewDTO: Codable {
             let symbol: String 
-            
-            /// 웹사이트: https://ethereum.org/ko/
             let websiteURL: String?
-            
-            /// 최초발행: 2015.07.
-            let startDate: String
-            
-            /// 디지털 자산 소개, 문장을 자연스럽게 연결하기 :
-            /// 이더리움은 비탈릭 부테린이 개발한 블록체인 기반의 분산 컴퓨팅 플랫폼이자 운영 체제입니다. 스마트 계약 기능을 제공하여 다양한 탈중앙화 애플리케이션(DApps)을 개발할 수 있도록 지원합니다. 이더리움의 네이티브 암호화폐인 이더(ETH)는 네트워크에서의 거래 수수료 및 계산 서비스를 위한 연료로 사용됩니다. 이더리움은 블록체인 기술의 활용 범위를 확장하여 디지털 자산의 새로운 가능성을 열었습니다.
+            let launchDate: String
             let description: String
         }
         
-        1. 답변할 항목은 위에 제공한 Swift 구조체의 주석에 따라 내용을 구성
-        2. JSON 형식과 변수 또한 제공한 구조체와 통일
-        3. 마크다운 사용 금지
-        위 세가지 규칙을 적용해서 코인 "\(coin.koreanName)"에 대한 개요를 JSON 형식으로 답변해줘.
+        "\(coin.koreanName)" 개요를 위 JSON 형식으로 작성 (마크다운 금지)
         """
         
         fetch(
@@ -76,7 +65,7 @@ final class ReportViewModel: ObservableObject {
                     ‣ 심볼: \(data.symbol)
                     ‣ 웹사이트: \(data.websiteURL ?? "없음")
                     
-                    ‣ 최초발행: \(data.startDate)
+                    ‣ 최초발행: \(data.launchDate)
                     
                     ‣ 소개: \(data.description)
                     """
@@ -89,40 +78,28 @@ final class ReportViewModel: ObservableObject {
     
     private func fetchTodayTopNews() {
         let content = """
-            struct CoinTodayNewsDTO: Codable { // 주석은 주어진 키워드가 '비트코인'인 경우 예상 응답
-                /// 오늘 시장 분위기
-                /// 비트코인은 최근 아마존을 제치고 세계 5위 자산으로 올라서는 성과를 달성했으나, 최근 5일 연속 가격이 하락하며 3주 만에 최저치를 기록했습니다. 8월은 비수기로 예상되며, 가격이 11만 2000달러까지 하락할 가능성이 제기되고 있습니다. JP모건 CEO는 비트코인에 대한 회의적인 입장을 밝히면서도 고객의 선택을 존중하겠다는 입장을 표명했습니다. 가상화폐 시장 전반이 하락세를 보이고 있으며, 주요 코인들이 큰 폭으로 하락하고 있습니다. 시장 분위기는 전반적으로 부정적이며, 가격 하락과 비수기 전망으로 인해 투자자들의 불안감이 커지고 있습니다.
-                let today: String
-                
-                /// 뉴스 배열, 3개
-                let articles: [CoinArticleDTO]
-            }
+        struct CoinTodayNewsDTO: Codable {
+            let todaySentiment: String
+            let articles: [CoinArticleDTO]
+        }
         
-            struct CoinArticleDTO: Codable {
-                /// 뉴스 헤드라인
-                let title: String
-                
-                /// 뉴스 한 줄 요약
-                let summary: String
-                
-                /// 뉴스 원문 링크
-                let url: String
-            }
+        struct CoinArticleDTO: Codable {
+            let title: String
+            let summary: String
+            let url: String
+        }
         
-            1. 답변할 항목은 위에 제공한 Swift 구조체의 주석에 따라 내용을 구성
-            2. JSON 형식과 변수 또한 구조체와 통일
-            3. 오늘 시장 분위기(today)의 경우에는 현재 국내 시간을 기준으로 24시간 동안의 뉴스를 근거로 간단하게 요약
-            4. 뉴스 배열의 경우에는 현재 국내 시간을 기준으로 24시간 동안의 뉴스 top 3 헤드라인과 한줄 요약을 제공
-            5. 마크다운 문법 사용 금지
+        1. 현재 국내 시간을 기준으로 최근 24시간 뉴스 기반
+        2. 뉴스 전반을 분석해 시장 분위기를 요약
         
-            위 다섯가지 규칙을 적용해서 "\(coin.koreanName)"에 대한 오늘 시장 분위기 요약본과 뉴스 배열을 제공해줘.
+        위 조건에 따라 "\(coin.koreanName)"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
         """
         
         fetch(
             content: content,
             decodeType: CoinTodayNewsDTO.self,
             onSuccess: { data in
-                self.coinTodayTrends = data.today
+                self.coinTodayTrends = data.todaySentiment
                 self.coinTodayTopNews = data.articles.map { CoinArticle(from: $0) }
             },
             onFailure: {
@@ -135,23 +112,14 @@ final class ReportViewModel: ObservableObject {
     private func fetchWeeklyTrends() {
         let content = """
             struct CoinWeeklyDTO: Codable {
-                /// 최근 일주일 가격 추이
                 let priceTrend: String
-                
-                /// 최근 일주일 거래량 변화
                 let volumeChange: String
-                
-                /// 지난 일주일간 가격 추이와 거래량 변화의 주요 원인
                 let reason: String
             }
             
-            1. 답변할 항목은 위에 제공한 Swift 구조체의 주석에 따라 내용을 구성
-            2. JSON 형식과 변수 또한 구조체와 통일
-            3. 현재 국내 시간을 기준으로 일주일 동안의 정보 사용
-            4. 출처 제외
-            5. 마크다운 문법 사용 금지
+            1. 현재 국내 시간을 기준으로 일주일 동안의 정보 사용
         
-            위 다섯가지 규칙을 적용해서 "\(coin.koreanName)"의 최근 일주일 가격 추이 및 거래량 변화 그리고 그 원인을 알려줘.
+            위 조건에 따라 "\(coin.koreanName)"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
         """
         
         fetch(

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
@@ -10,6 +10,9 @@ import Foundation
 final class ReportViewModel: ObservableObject {
     let coin: Coin
     let koreanName: String
+    
+    private let alanAPIService = AlanAPIService()
+    
     @Published var coinOverView: String = "AI가 정보를 준비하고 있어요"
     @Published var coinTodayTrends: String = "AI가 정보를 준비하고 있어요"
     @Published var coinWeeklyTrends: String = "AI가 정보를 준비하고 있어요"
@@ -18,49 +21,18 @@ final class ReportViewModel: ObservableObject {
     init(coin: Coin) {
         self.coin = coin
         self.koreanName = coin.koreanName
-        fetchOverView()
-        fetchTodayTopNews()
-        fetchWeeklyTrends()
-    }
-    
-    private func fetch<T: Decodable>(
-        content: String,
-        decodeType: T.Type,
-        onSuccess: @escaping (T) -> Void,
-        onFailure: @escaping () -> Void
-    ) {
-        Task {
-            do {
-                let answer = try await AlanAPIService().fetchAnswer(content: content)
-                guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
-                    await MainActor.run { onFailure() }
-                    return
-                }
-                let data = try JSONDecoder().decode(T.self, from: jsonData)
-                await MainActor.run { onSuccess(data) }
-            } catch {
-                print("오류 발생: \(error.localizedDescription)")
-                await MainActor.run { onFailure() }
-            }
+        
+        Task.detached(priority: .background) {
+            await self.fetchOverViewAsync()
+            await self.fetchTodayTopNewsAsync()
+            await self.fetchWeeklyTrendsAsync()
         }
     }
     
-    private func fetchOverView() {
-        let content = """
-        struct CoinOverviewDTO: Codable {
-            let symbol: String 
-            let websiteURL: String?
-            let launchDate: String
-            let description: String
-        }
-        
-        "\(coin.koreanName)" 개요를 위 JSON 형식으로 작성 (마크다운 금지)
-        """
-        
-        fetch(
-            content: content,
-            decodeType: CoinOverviewDTO.self,
-            onSuccess: { data in
+    private func fetchOverViewAsync() async {
+        do {
+            let data = try await alanAPIService.fetchOverview(for: coin)
+            await MainActor.run {
                 self.coinOverView = """
                     ‣ 심볼: \(data.symbol)
                     ‣ 웹사이트: \(data.websiteURL ?? "없음")
@@ -69,63 +41,35 @@ final class ReportViewModel: ObservableObject {
                     
                     ‣ 소개: \(data.description)
                     """
-            },
-            onFailure: {
+            }
+        } catch {
+            print("오류 발생: \(error.localizedDescription)")
+            await MainActor.run {
                 self.coinOverView = "데이터를 불러오는 데 실패했어요"
             }
-        )
+        }
     }
     
-    private func fetchTodayTopNews() {
-        let content = """
-        struct CoinTodayNewsDTO: Codable {
-            let todaySentiment: String
-            let articles: [CoinArticleDTO]
-        }
-        
-        struct CoinArticleDTO: Codable {
-            let title: String
-            let summary: String
-            let url: String
-        }
-        
-        1. 현재 국내 시간을 기준으로 최근 24시간 뉴스 기반
-        2. 뉴스 전반을 분석해 시장 분위기를 요약
-        
-        위 조건에 따라 "\(coin.koreanName)"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
-        """
-        
-        fetch(
-            content: content,
-            decodeType: CoinTodayNewsDTO.self,
-            onSuccess: { data in
+    private func fetchTodayTopNewsAsync() async {
+        do {
+            let data = try await alanAPIService.fetchTodayNews(for: coin)
+            await MainActor.run {
                 self.coinTodayTrends = data.todaySentiment
                 self.coinTodayTopNews = data.articles.map { CoinArticle(from: $0) }
-            },
-            onFailure: {
+            }
+        } catch {
+            print("오류 발생: \(error.localizedDescription)")
+            await MainActor.run {
                 self.coinTodayTrends = "데이터를 불러오는 데 실패했어요"
                 self.coinTodayTopNews = [CoinArticle(title: "데이터를 불러오는데 실패했어요", summary: "", url: "")]
             }
-        )
+        }
     }
     
-    private func fetchWeeklyTrends() {
-        let content = """
-            struct CoinWeeklyDTO: Codable {
-                let priceTrend: String
-                let volumeChange: String
-                let reason: String
-            }
-            
-            1. 현재 국내 시간을 기준으로 일주일 동안의 정보 사용
-        
-            위 조건에 따라 "\(coin.koreanName)"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
-        """
-        
-        fetch(
-            content: content,
-            decodeType: CoinWeeklyDTO.self,
-            onSuccess: { data in
+    private func fetchWeeklyTrendsAsync() async {
+        do {
+            let data = try await alanAPIService.fetchWeeklyTrends(for: coin)
+            await MainActor.run {
                 self.coinWeeklyTrends = """
                     ‣ 가격 추이: \(data.priceTrend)
                     
@@ -133,10 +77,12 @@ final class ReportViewModel: ObservableObject {
                     
                     ‣ 원인: \(data.reason)
                     """
-            },
-            onFailure: {
+            }
+        } catch {
+            print("오류 발생: \(error.localizedDescription)")
+            await MainActor.run {
                 self.coinWeeklyTrends = "데이터를 불러오는 데 실패했어요"
             }
-        )
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- #71 
- #72 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- ~~키 2개 폭파로~~ content에 있던 주석을 제거하고, 나머지 프롬프트도 최대한 짧게 수정했습니다.
- ReportViewModel에서 작성했던 fetch method를 AlanAPIService로 이동했습니다.
- 데이터를 가져오는데 실패하는 이유가 크게 두가지가 있었습니다
    1. 앨런이 응답을 거부함
        - 데이터를 가져오지 못했을 경우 띄울 placeholder 작업이 필요할 것 같습니다. 현재는 데이터를 가져오는데 실패했다는 text를 띄우고 있습니다. 추후 디자인이 확정되면 수정하도록 하겠습니다.
    2. A 코인 리포트를 작성, 다른 창에서 B 코인 리포트를 요청하면, 랜덤으로 A 코인에 대한 답변이 B 코인으로 내려오면서 디코딩에러가 발생하는 경우
       - fetch를 순차적으로 실행되도록 수정했더니 해당 부분은 해결된 것 같습니다 (정확한 이유와 해결 방법은 아닌 것 같아서, 나중에 다시 또 발생할 수도 있겠다는 두려움은 있습니다...)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- 강호님이 말씀 주신대로 AlanAPIService로 fetch method를 이동했는데, 맞는 방향인지 확인 부탁드리겠습니다!
- 희재님이 말씀 주신대로 위에서부터 순서대로 fetch 되도록 수정했습니다.