### PR TITLE
Alan API 작업 별로 clientID 분기하기

### DIFF
--- a/AIProject/AIProject/Data/Model/AlanAction.swift
+++ b/AIProject/AIProject/Data/Model/AlanAction.swift
@@ -1,0 +1,17 @@
+//
+//  AlanAction.swift
+//  AIProject
+//
+//  Created by Kitcat Seo on 8/5/25.
+//
+
+import Foundation
+
+enum AlanAction {
+    /// 코인 추천
+    case coinRecomendation
+    /// 코인 리포트
+    case coinReportGeneration
+    /// 코인 ID 추출
+    case coinIDExtraction
+}

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/DashboardViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/DashboardViewModel.swift
@@ -25,7 +25,7 @@ final class DashboardViewModel: ObservableObject {
             let markets = try await upbitService.fetchMarkets()
             let coinIDs = markets.map { $0.coinID }.filter { $0.contains("KRW") }
             let prompt = Prompt.recommendCoin(preference: "초보자", bookmark: "비트코인, 이더리움", coinIDs: coinIDs.joined(separator: " "))
-            let jsonString = try await alanService.fetchAnswer(content: prompt.content).content.extractedJSON
+            let jsonString = try await alanService.fetchAnswer(content: prompt.content, action: .coinRecomendation).content.extractedJSON
 
             if let jsonData = jsonString.data(using: .utf8) {
                 let recommendCoinDTOs = try JSONDecoder().decode([RecommendCoinDTO].self, from: jsonData)

--- a/AIProject/AIProject/Features/MyPage/ViewModel/ImageProcessViewModel.swift
+++ b/AIProject/AIProject/Features/MyPage/ViewModel/ImageProcessViewModel.swift
@@ -65,7 +65,7 @@ class ImageProcessViewModel: ObservableObject {
                 let answer = try await AlanAPIService().fetchAnswer(content: """
             아래의 문자열 배열에서 가상화폐의 이름을 찾아서 해당 코인의 영문 심볼들을 반환해. 오타가 있다면 고쳐주고 "," 로 구분해서 JSON으로 반환해.
             \(text)
-            """)
+            """, action: .coinIDExtraction)
                 
                 let convertedSymbols = answer.content.extractedJSON
                     .replacingOccurrences(of: "\"", with:"") // "\" 문자 제거하기

--- a/AIProject/AIProject/Info.plist
+++ b/AIProject/AIProject/Info.plist
@@ -2,7 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ALAN_API_KEY</key>
-	<string>$(ALAN_API_KEY)</string>
+	<key>ALAN_API_KEY_COIN_ID_EXTRACTION</key>
+	<string>$(ALAN_API_KEY_COIN_ID_EXTRACTION)</string>
+	<key>ALAN_API_KEY_COIN_RECOMENDATION</key>
+	<string>${ALAN_API_KEY_COIN_RECOMENDATION}</string>
+	<key>ALAN_API_KEY_COIN_REPORT_GENERATION</key>
+	<string>${ALAN_API_KEY_COIN_REPORT_GENERATION}</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Conflicts:
#	AIProject/AIProject/Features/Dashboard/ViewModel/DashboardViewModel.swift

## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> close #88 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- Info 파일에 API 키 변수 등록
- Alan 작업 목록을 담는 Enum 생성
- Alan 작업에 따라 API 키를 전환하는 함수 추가
- fetchAnswer에 파라메터 추가해서 분기
- 기존 fetchAnswer 함수 호출부에 반영

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

다른 작업들은 dev 기준으로 UI에서 조작할 수 있는 부분이 안보여서 테스트를 하지 않았습니다.
각자 작업하신 부분들이 기존과 같이 잘 동작하는지 확인하시고 특이사항 없을 시 머지해주시면 감사하겠습니다!