### PR TITLE
SubHeaderView에서 Description을 받을 수 있도록 수정

### DIFF
--- a/AIProject/AIProject/Features/Base/HeaderView.swift
+++ b/AIProject/AIProject/Features/Base/HeaderView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 /// 헤더에 표시할 제목을 필수로 전달해주세요.
 /// 마켓이나 북마크 메뉴일 경우 각 파라메터에 true 값을 넣어주세요.
 struct HeaderView: View {
-    @State var heading: String
+    let heading: String
     
-    @State var showSearchButton = false
-    @State var isBookmarkView = false
+    var showSearchButton = false
+    var isBookmarkView = false
     
     var body: some View {
         HStack {
@@ -66,6 +66,6 @@ struct HeaderView: View {
 }
 
 #Preview {
-    HeaderView(heading: "북마크 관리",isBookmarkView: true)
+    HeaderView(heading: "북마크 관리", isBookmarkView: true)
     SubheaderView(subheading: "북마크하신 코인들을 분석해봤어요")
 }

--- a/AIProject/AIProject/Features/Base/HeaderView.swift
+++ b/AIProject/AIProject/Features/Base/HeaderView.swift
@@ -67,5 +67,6 @@ struct HeaderView: View {
 
 #Preview {
     HeaderView(heading: "북마크 관리", isBookmarkView: true)
+        .padding(.bottom, 16)
     SubheaderView(subheading: "북마크하신 코인들을 분석해봤어요")
 }

--- a/AIProject/AIProject/Features/Base/SubheaderView.swift
+++ b/AIProject/AIProject/Features/Base/SubheaderView.swift
@@ -27,7 +27,6 @@ struct SubheaderView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
-        .padding(.top, 16)
     }
 }
 

--- a/AIProject/AIProject/Features/Base/SubheaderView.swift
+++ b/AIProject/AIProject/Features/Base/SubheaderView.swift
@@ -8,22 +8,29 @@
 import SwiftUI
 
 /// 서브헤더에 표시할 제목을 필수로 전달해주세요.
+/// 제목 아래에 추가할 설명이 있다면 전달해주세요.
 struct SubheaderView: View {
-    @State var subheading: String
+    let subheading: String
+    var description: String? = nil
     
     var body: some View {
-        HStack {
+        VStack(alignment: .leading, spacing: 8) {
             Text(subheading)
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 18, weight: .bold))
                 .foregroundStyle(.aiCoLabel)
             
-            Spacer()
+            if let description {
+                Text(description)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.aiCoLabel)
+            }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
-        .padding(.vertical, 4)
+        .padding(.top, 16)
     }
 }
 
 #Preview {
-    SubheaderView(subheading: "북마크하신 코인들을 분석해봤어요")
+    SubheaderView(subheading: "이런 코인은 어떠세요?", description: "회원님의 관심 코인을 기반으로 새로운 코인을 추천해드려요")
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
@@ -23,9 +23,8 @@ struct CoinDetailView: View {
             // 차트, 보고서 view
             VStack {
                 switch selectedTab {
-                case 0: ChartView(coin: coin)
                 case 1: ReportView(coin: coin)
-                default: /*ChartView()*/ Text("차트")
+                default: ChartView(coin: coin)
                 }
             }
             .frame(maxHeight: .infinity)

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -43,14 +43,14 @@ struct ReportSectionView: View {
     var body: some View {
         VStack(spacing: 0) {
             Group {
-                Text(title)
-                    .font(.system(size: 17, weight: .bold))
+                SubheaderView(subheading: title)
                     .padding(.bottom, 8)
                 
                 ForEach(contents, id: \.self) { content in
                     VStack(spacing: 0) {
                         Text(content)
                             .font(.system(size: 13))
+                            .foregroundStyle(.aiCoLabel)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(16)
                     }
@@ -60,10 +60,10 @@ struct ReportSectionView: View {
                     }
                     .padding(.bottom, 10)
                 }
+                .padding(.horizontal, 16)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal)
         .padding(.bottom, 20)
     }
 }
@@ -78,8 +78,7 @@ struct ReportNewsSectionView: View {
     var body: some View {
         VStack(spacing: 0) {
             Group {
-                Text(title)
-                    .font(.system(size: 17, weight: .bold))
+                SubheaderView(subheading: title)
                     .padding(.bottom, 8)
                 
                 ForEach(articles) { article in
@@ -102,12 +101,14 @@ struct ReportNewsSectionView: View {
                         
                         Text(article.title)
                             .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(.aiCoLabel)
                             .padding(.horizontal)
                             .padding(.bottom, 8)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         
                         Text(article.summary)
                             .font(.system(size: 13))
+                            .foregroundStyle(.aiCoLabel)
                             .padding(.horizontal)
                             .padding(.bottom, 16)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -118,10 +119,10 @@ struct ReportNewsSectionView: View {
                     }
                     .padding(.bottom, 10)
                 }
+                .padding(.horizontal, 16)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal)
         .padding(.bottom, 20)
         .sheet(item: $safariItem) { item in
             SafariView(url: item.url)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- #97 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- HeaderView, SubHeaderView `@state` 제거
- SubHeaderView의 subheading font weight .bold로 변경
- SubHeaderView에 description 추가

### 스크린샷 (선택)
<img width="346" height="134" alt="image" src="https://github.com/user-attachments/assets/4d1b5718-128e-4997-8ce3-5aa18d232f32" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- SubHeaderView 사용하는 View 중 확인 가능한 View는 기존 UI와 달라지지 않도록 수정했습니다.
- BookmarkBulkInsertView를 열 수 있는 버튼을 못찾아서 확인 못했습니다. 😢
    - 아래 부분에서 description을 사용하셔도 괜찮을 것 같아요! 
    ```swift
    SubheaderView(subheading: "보유 코인이나 관심 코인을 한번에 등록하시려면 스크린샷을 업로드하세요.")

    Text("아이코가 자동으로 북마크를 등록해드려요.")
        .padding(.horizontal, 16)
    ```