### PR TITLE
 대시보드 - AI 브리핑 공포탐욕지수

### DIFF
--- a/AIProject/AIProject/Core/Remote/APIService/FearGreedAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/FearGreedAPIService.swift
@@ -1,0 +1,28 @@
+//
+//  FearGreedAPIService.swift
+//  AIProject
+//
+//  Created by 장지현 on 8/6/25.
+//
+
+import Foundation
+
+/// 공포 탐욕 지수 API 관련 서비스를 제공합니다.
+final class FearGreedAPIService {
+    private let network: NetworkClient
+    private let endpoint: String = "https://api.alternative.me/fng/"
+
+    init(networkClient: NetworkClient = .init()) {
+        self.network = networkClient
+    }
+    
+    /// Alternative의 공포 탐욕 지수 데이터를 가져옵니다.
+    /// - Returns: 공포 탐욕 지수, 상태 정보
+    func fetchData() async throws -> [FearGreedIndexDTO] {
+        let urlString = "\(endpoint)"
+        guard let url = URL(string: urlString) else { throw NetworkError.invalidURL }
+        let fearGreedResponseDTO: FearGreedResponseDTO = try await network.request(url: url)
+
+        return fearGreedResponseDTO.data
+    }
+}

--- a/AIProject/AIProject/Data/Response/FearGreedResponse/FearGreedResponseDTO.swift
+++ b/AIProject/AIProject/Data/Response/FearGreedResponse/FearGreedResponseDTO.swift
@@ -1,0 +1,30 @@
+//
+//  FearGreedResponseDTO.swift
+//  AIProject
+//
+//  Created by 장지현 on 8/6/25.
+//
+
+import Foundation
+
+struct FearGreedResponseDTO: Codable {
+    let data: [FearGreedIndexDTO]
+}
+
+struct FearGreedIndexDTO: Codable {
+    /// 공포 탐욕 지수
+    let value: String
+    /// 공포 탐욕 상태
+    let valueClassification: String
+    /// 기준 시간 (Unix Epoch)
+    let timestamp: String
+    /// 기준 시간으로 부터 경과한 시간 (Unix Epoch)
+    let timeUntilUpdate: String
+    
+    enum CodingKeys: String, CodingKey {
+        case value = "value"
+        case valueClassification = "value_classification"
+        case timestamp = "timestamp"
+        case timeUntilUpdate = "time_until_update"
+    }
+}

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/FearGreedViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/FearGreedViewModel.swift
@@ -19,5 +19,39 @@ final class FearGreedViewModel: ObservableObject {
     }
     
     private func fetchFearGreedAsync() async {
+        do {
+            let data = try await FearGreedAPIService().fetchData()
+            
+            guard let fearGreedIndex = data.first else {
+                print("Fear And Greed Index: No Data")
+                return
+            }
+            
+            guard let doubleIndex = Double(fearGreedIndex.value) else {
+                print("Fear And Greed Index: Failed to convert String to CGFloat")
+                return
+            }
+            
+            await MainActor.run {
+                self.indexValue = CGFloat(doubleIndex)
+                switch fearGreedIndex.valueClassification {
+                case "Extreme Fear":
+                    fearGreed = .extremeFear
+                case "Fear":
+                    fearGreed = .fear
+                case "Neutral":
+                    fearGreed = .neutral
+                case "Greed":
+                    fearGreed = .greed
+                case "Extreme Greed":
+                    fearGreed = .extremeGreed
+                default:
+                    print("Fear And Greed Index: Invalid valueClassification")
+                }
+                self.classification = fearGreed.description
+            }
+        } catch {
+            
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- #69 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- FearGreedAPIService 추가
    - [alternative](https://alternative.me/crypto/fear-and-greed-index/) 에서 제공하는 Crypto Fear & Greed Index에서 공포 탐욕 지수를 받아오는 APIService를 구현했습니다.
- 대시보드 API 연결
   - 전달해주는 text에 따라 FearGreed enum값을 판단하고, enum을 통해 UI가 업데이트 되도록 했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
