### PR TITLE
검색 구현 및 swift-async-algorithms 라이브러리 추가

### DIFF
--- a/AIProject/AIProject.xcodeproj/project.pbxproj
+++ b/AIProject/AIProject.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		A9C265DA2E40B11D00C987E5 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = A9C265D92E40B11D00C987E5 /* Secrets.xcconfig */; };
 		A9C265DB2E40B12500C987E5 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = A9C265D92E40B11D00C987E5 /* Secrets.xcconfig */; };
 		A9C265DC2E40B12500C987E5 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = A9C265D92E40B11D00C987E5 /* Secrets.xcconfig */; };
+		26621BE42E423BE70083E177 /* AsyncAlgorithms in Frameworks */ = {isa = PBXBuildFile; productRef = 26621BE32E423BE70083E177 /* AsyncAlgorithms */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26621BE42E423BE70083E177 /* AsyncAlgorithms in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,6 +135,7 @@
 			);
 			name = AIProject;
 			packageProductDependencies = (
+				26621BE32E423BE70083E177 /* AsyncAlgorithms */,
 			);
 			productName = AIProject;
 			productReference = B7B040032E387FCF005DE0BA /* AIProject.app */;
@@ -216,6 +219,9 @@
 			);
 			mainGroup = B7B03FFA2E387FCF005DE0BA;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				26621BE22E423BE70083E177 /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = B7B040042E387FCF005DE0BA /* Products */;
 			projectDirPath = "";
@@ -594,6 +600,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		26621BE22E423BE70083E177 /* XCRemoteSwiftPackageReference "swift-async-algorithms" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-async-algorithms.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		26621BE32E423BE70083E177 /* AsyncAlgorithms */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 26621BE22E423BE70083E177 /* XCRemoteSwiftPackageReference "swift-async-algorithms" */;
+			productName = AsyncAlgorithms;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B7B03FFB2E387FCF005DE0BA /* Project object */;
 }

--- a/AIProject/AIProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AIProject/AIProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "13678df8bf756b5a26255707c7a7a2f70f4fa09e8466f4b4d0ca97436222d7d0",
+  "pins" : [
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/AIProject/AIProject/Core/Remote/APIService/UpbitAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/UpbitAPIService.swift
@@ -16,14 +16,14 @@ final class UpBitAPIService {
         self.network = networkClient
     }
 
-    /// 전체 마켓의 정보를 가져옵니다.
+    /// 전체 마켓의 KRW(원화) 정보를 가져옵니다.
     /// - Returns: 마켓 정보들의 배열
     func fetchMarkets() async throws -> [CoinDTO] {
         let urlString = "\(endpoint)/market/all"
         guard let url = URL(string: urlString) else { throw NetworkError.invalidURL }
         let coinDTOs: [CoinDTO] = try await network.request(url: url)
 
-        return coinDTOs
+        return coinDTOs.filter { $0.coinID.contains("KRW") }
     }
     
     

--- a/AIProject/AIProject/Core/Util/Data+Util.swift
+++ b/AIProject/AIProject/Core/Util/Data+Util.swift
@@ -1,0 +1,15 @@
+//
+//  Data+Util.swift
+//  AIProject
+//
+//  Created by 강대훈 on 8/6/25.
+//
+
+import Foundation
+
+extension Data {
+    /// 코인 데이터로 디코드해서 반환합니다.
+    var toCoin: Coin? {
+        try? JSONDecoder().decode(Coin.self, from: self)
+    }
+}

--- a/AIProject/AIProject/Data/Model/Coin.swift
+++ b/AIProject/AIProject/Data/Model/Coin.swift
@@ -7,7 +7,13 @@
 
 import Foundation
 
-struct Coin: Identifiable {
+struct Coin: Identifiable, Codable {
     let id: String
     let koreanName: String
+}
+
+extension Coin {
+    var toData: Data? {
+        try? JSONEncoder().encode(self)
+    }
 }

--- a/AIProject/AIProject/Data/Model/Coin.swift
+++ b/AIProject/AIProject/Data/Model/Coin.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Coin: Identifiable, Codable {
+struct Coin: Identifiable, Hashable, Codable {
     let id: String
     let koreanName: String
 }

--- a/AIProject/AIProject/Features/Search/EmptySearchResultView.swift
+++ b/AIProject/AIProject/Features/Search/EmptySearchResultView.swift
@@ -1,0 +1,30 @@
+//
+//  EmptySearchResultView.swift
+//  AIProject
+//
+//  Created by 강대훈 on 8/6/25.
+//
+
+import SwiftUI
+
+struct EmptySearchResultView: View {
+    let searchText: String
+
+    var body: some View {
+        VStack {
+            Image(systemName: "magnifyingglass")
+                .resizable()
+                .frame(width: 70, height: 70)
+            Text("\"\(searchText)\"에 대한 결과 없음")
+                .font(.system(size: 25))
+                .fontWeight(.bold)
+                .padding(.vertical, 3)
+            Text("맞춤법을 확인하거나 새로운 검색을 시도하십시오.")
+                .foregroundStyle(.gray)
+        }
+    }
+}
+
+#Preview {
+    EmptySearchResultView(searchText: "비트")
+}

--- a/AIProject/AIProject/Features/Search/RecentSearchListView.swift
+++ b/AIProject/AIProject/Features/Search/RecentSearchListView.swift
@@ -1,0 +1,50 @@
+//
+//  RecentSearchListView.swift
+//  AIProject
+//
+//  Created by 강대훈 on 8/6/25.
+//
+
+import SwiftUI
+
+struct RecentSearchListView: View {
+    @ObservedObject var viewModel: SearchViewModel
+    @Binding var selectedCoin: Coin?
+    
+    var body: some View {
+        ForEach(viewModel.recentSearchCoins) { coin in
+            HStack {
+                Image(systemName: "swift")
+                Text(coin.koreanName)
+                    .bold()
+                Text(coin.id)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.gray)
+
+                Spacer()
+
+                Button {
+                    viewModel.removeRecentSearchKeyword(coin)
+                } label: {
+                    Image(systemName: "multiply")
+                        .foregroundStyle(.aiCoPositive)
+                }
+            }
+            .onTapGesture {
+                viewModel.updateRecentSearchKeyword(coin)
+                selectedCoin = coin
+            }
+        }
+        .padding(.vertical, 5)
+        .navigationDestination(item: $selectedCoin) { coin in
+            CoinDetailView(coin: coin)
+        }
+    }
+}
+
+#Preview {
+    RecentSearchListView(
+        viewModel: SearchViewModel(),
+        selectedCoin: .constant(Coin(id: "KRW-BTC", koreanName: "비트코인"))
+    )
+}

--- a/AIProject/AIProject/Features/Search/RecentSearchView.swift
+++ b/AIProject/AIProject/Features/Search/RecentSearchView.swift
@@ -22,7 +22,7 @@ struct RecentSearchView: View {
             if viewModel.recentSearchCoins.isEmpty {
                 HStack {
                     Text("검색 내역이 없어요.")
-                        .font(.callout)
+                        .font(.system(size: 15))
                         .foregroundStyle(.gray)
                     Spacer()
                 }
@@ -33,7 +33,7 @@ struct RecentSearchView: View {
                         Text(coin.koreanName)
                             .bold()
                         Text(coin.id)
-                            .font(.footnote)
+                            .font(.system(size: 13))
                             .foregroundStyle(.gray)
 
                         Spacer()

--- a/AIProject/AIProject/Features/Search/RecentSearchView.swift
+++ b/AIProject/AIProject/Features/Search/RecentSearchView.swift
@@ -18,7 +18,7 @@ struct RecentSearchView: View {
                 Spacer()
             }
 
-            if viewModel.bookMarkCoins.isEmpty {
+            if viewModel.recentSearchCoins.isEmpty {
                 HStack {
                     Text("검색 내역이 없어요.")
                         .font(.callout)
@@ -26,7 +26,7 @@ struct RecentSearchView: View {
                     Spacer()
                 }
             } else {
-                ForEach(viewModel.bookMarkCoins) { coin in
+                ForEach(viewModel.recentSearchCoins) { coin in
                     HStack {
                         Image(systemName: "swift")
                         Text(coin.koreanName)
@@ -43,7 +43,7 @@ struct RecentSearchView: View {
         }
         .padding()
         .onAppear {
-            viewModel.loadBookMarkCoins()
+            viewModel.loadRecentSearchKeyword()
         }
     }
 }

--- a/AIProject/AIProject/Features/Search/RecentSearchView.swift
+++ b/AIProject/AIProject/Features/Search/RecentSearchView.swift
@@ -27,33 +27,7 @@ struct RecentSearchView: View {
                     Spacer()
                 }
             } else {
-                ForEach(viewModel.recentSearchCoins) { coin in
-                    HStack {
-                        Image(systemName: "swift")
-                        Text(coin.koreanName)
-                            .bold()
-                        Text(coin.id)
-                            .font(.system(size: 13))
-                            .foregroundStyle(.gray)
-
-                        Spacer()
-
-                        Button {
-                            viewModel.removeRecentSearchKeyword(coin)
-                        } label: {
-                            Image(systemName: "multiply")
-                                .foregroundStyle(.aiCoPositive)
-                        }
-                    }
-                    .onTapGesture {
-                        viewModel.updateRecentSearchKeyword(coin)
-                        selectedCoin = coin
-                    }
-                }
-                .padding(.vertical, 5)
-                .navigationDestination(item: $selectedCoin) { coin in
-                    CoinDetailView(coin: coin)
-                }
+                RecentSearchListView(viewModel: viewModel, selectedCoin: $selectedCoin)
             }
         }
         .padding()

--- a/AIProject/AIProject/Features/Search/RecentSearchView.swift
+++ b/AIProject/AIProject/Features/Search/RecentSearchView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct RecentSearchView: View {
     @ObservedObject var viewModel: SearchViewModel
+    @State private var selectedCoin: Coin? = nil
 
     var body: some View {
         ScrollView {
@@ -44,8 +45,15 @@ struct RecentSearchView: View {
                                 .foregroundStyle(.aiCoPositive)
                         }
                     }
+                    .onTapGesture {
+                        viewModel.addRecentSearchKeyword(coin)
+                        selectedCoin = coin
+                    }
                 }
                 .padding(.vertical, 5)
+                .navigationDestination(item: $selectedCoin) { coin in
+                    CoinDetailView(coin: coin)
+                }
             }
         }
         .padding()

--- a/AIProject/AIProject/Features/Search/RecentSearchView.swift
+++ b/AIProject/AIProject/Features/Search/RecentSearchView.swift
@@ -36,6 +36,13 @@ struct RecentSearchView: View {
                             .foregroundStyle(.gray)
 
                         Spacer()
+
+                        Button {
+                            viewModel.removeRecentSearchKeyword(coin)
+                        } label: {
+                            Image(systemName: "multiply")
+                                .foregroundStyle(.aiCoPositive)
+                        }
                     }
                 }
                 .padding(.vertical, 5)

--- a/AIProject/AIProject/Features/Search/RecentSearchView.swift
+++ b/AIProject/AIProject/Features/Search/RecentSearchView.swift
@@ -1,0 +1,53 @@
+//
+//  RecentSearchView.swift
+//  AIProject
+//
+//  Created by 강대훈 on 8/5/25.
+//
+
+import SwiftUI
+
+struct RecentSearchView: View {
+    @ObservedObject var viewModel: SearchViewModel
+
+    var body: some View {
+        ScrollView {
+            HStack {
+                Text("최근 검색")
+                    .padding(.vertical, 5)
+                Spacer()
+            }
+
+            if viewModel.bookMarkCoins.isEmpty {
+                HStack {
+                    Text("검색 내역이 없어요.")
+                        .font(.callout)
+                        .foregroundStyle(.gray)
+                    Spacer()
+                }
+            } else {
+                ForEach(viewModel.bookMarkCoins) { coin in
+                    HStack {
+                        Image(systemName: "swift")
+                        Text(coin.koreanName)
+                            .bold()
+                        Text(coin.id)
+                            .font(.footnote)
+                            .foregroundStyle(.gray)
+
+                        Spacer()
+                    }
+                }
+                .padding(.vertical, 5)
+            }
+        }
+        .padding()
+        .onAppear {
+            viewModel.loadBookMarkCoins()
+        }
+    }
+}
+
+#Preview {
+    RecentSearchView(viewModel: SearchViewModel())
+}

--- a/AIProject/AIProject/Features/Search/RecentSearchView.swift
+++ b/AIProject/AIProject/Features/Search/RecentSearchView.swift
@@ -46,7 +46,7 @@ struct RecentSearchView: View {
                         }
                     }
                     .onTapGesture {
-                        viewModel.addRecentSearchKeyword(coin)
+                        viewModel.updateRecentSearchKeyword(coin)
                         selectedCoin = coin
                     }
                 }

--- a/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
+++ b/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct RelatedKeywordView: View {
     @ObservedObject var viewModel: SearchViewModel
-    
+    @State private var selectedCoin: Coin? = nil
+
     var body: some View {
         List {
             ForEach(viewModel.relatedCoins) { coin in
@@ -21,10 +22,15 @@ struct RelatedKeywordView: View {
                         .foregroundStyle(.gray)
                     Spacer()
                 }
+                .contentShape(Rectangle())
                 .onTapGesture {
                     viewModel.addRecentSearchKeyword(coin)
+                    selectedCoin = coin
                 }
             }
+        }
+        .navigationDestination(item: $selectedCoin) { coin in
+            CoinDetailView(coin: coin)
         }
     }
 }

--- a/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
+++ b/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
@@ -24,7 +24,7 @@ struct RelatedKeywordView: View {
                 }
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    viewModel.addRecentSearchKeyword(coin)
+                    viewModel.updateRecentSearchKeyword(coin)
                     selectedCoin = coin
                 }
             }

--- a/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
+++ b/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
@@ -18,7 +18,7 @@ struct RelatedKeywordView: View {
                     Image(systemName: "swift")
                     Text(coin.koreanName)
                     Text(coin.id)
-                        .font(.footnote)
+                        .font(.system(size: 13))
                         .foregroundStyle(.gray)
                     Spacer()
                 }

--- a/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
+++ b/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
@@ -19,6 +19,10 @@ struct RelatedKeywordView: View {
                     Text(coin.id)
                         .font(.footnote)
                         .foregroundStyle(.gray)
+                    Spacer()
+                }
+                .onTapGesture {
+                    viewModel.addRecentSearchKeyword(coin)
                 }
             }
         }

--- a/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
+++ b/AIProject/AIProject/Features/Search/RelatedKeywordView.swift
@@ -1,0 +1,30 @@
+//
+//  RelatedKeywordView.swift
+//  AIProject
+//
+//  Created by 강대훈 on 8/5/25.
+//
+
+import SwiftUI
+
+struct RelatedKeywordView: View {
+    @ObservedObject var viewModel: SearchViewModel
+    
+    var body: some View {
+        List {
+            ForEach(viewModel.relatedCoins) { coin in
+                HStack {
+                    Image(systemName: "swift")
+                    Text(coin.koreanName)
+                    Text(coin.id)
+                        .font(.footnote)
+                        .foregroundStyle(.gray)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    RelatedKeywordView(viewModel: SearchViewModel())
+}

--- a/AIProject/AIProject/Features/Search/SearchResultListView.swift
+++ b/AIProject/AIProject/Features/Search/SearchResultListView.swift
@@ -1,15 +1,15 @@
 //
-//  RelatedKeywordView.swift
+//  SearchResultListView.swift
 //  AIProject
 //
-//  Created by 강대훈 on 8/5/25.
+//  Created by 강대훈 on 8/6/25.
 //
 
 import SwiftUI
 
-struct RelatedKeywordView: View {
+struct SearchResultListView: View {
     @ObservedObject var viewModel: SearchViewModel
-    @State private var selectedCoin: Coin? = nil
+    @Binding var selectedCoin: Coin?
 
     var body: some View {
         List {
@@ -36,5 +36,8 @@ struct RelatedKeywordView: View {
 }
 
 #Preview {
-    RelatedKeywordView(viewModel: SearchViewModel())
+    SearchResultListView(
+        viewModel: SearchViewModel(),
+        selectedCoin: .constant(Coin(id: "KRW-BTC", koreanName: "비트코인"))
+    )
 }

--- a/AIProject/AIProject/Features/Search/SearchResultView.swift
+++ b/AIProject/AIProject/Features/Search/SearchResultView.swift
@@ -1,0 +1,27 @@
+//
+//  RelatedKeywordView.swift
+//  AIProject
+//
+//  Created by 강대훈 on 8/5/25.
+//
+
+import SwiftUI
+
+struct SearchResultView: View {
+    @ObservedObject var viewModel: SearchViewModel
+    @State private var selectedCoin: Coin? = nil
+    
+    let searchText: String
+
+    var body: some View {
+        if viewModel.relatedCoins.isEmpty {
+            EmptySearchResultView(searchText: searchText)
+        } else {
+            SearchResultListView(viewModel: viewModel, selectedCoin: $selectedCoin)
+        }
+    }
+}
+
+#Preview {
+    SearchResultView(viewModel: SearchViewModel(), searchText: "비트")
+}

--- a/AIProject/AIProject/Features/Search/SearchView.swift
+++ b/AIProject/AIProject/Features/Search/SearchView.swift
@@ -1,0 +1,33 @@
+//
+//  SearchView.swift
+//  AIProject
+//
+//  Created by 강대훈 on 8/5/25.
+//
+
+import SwiftUI
+
+struct SearchView: View {
+    @State private var searchText: String = ""
+    @StateObject private var viewModel = SearchViewModel()
+
+    var body: some View {
+        NavigationStack {
+            if searchText.isEmpty {
+                RecentSearchView(viewModel: viewModel)
+            } else {
+                RelatedKeywordView(viewModel: viewModel)
+            }
+        }
+        .searchable(text: $searchText, prompt: "코인 이름으로 검색하세요")
+        .onChange(of: searchText) {
+            Task {
+                await viewModel.sendKeyword(with: searchText)
+            }
+        }
+    }
+}
+
+#Preview {
+    SearchView()
+}

--- a/AIProject/AIProject/Features/Search/SearchView.swift
+++ b/AIProject/AIProject/Features/Search/SearchView.swift
@@ -16,7 +16,7 @@ struct SearchView: View {
             if searchText.isEmpty {
                 RecentSearchView(viewModel: viewModel)
             } else {
-            	RelatedKeywordView(viewModel: viewModel)
+                SearchResultView(viewModel: viewModel, searchText: searchText)
             }
         }
         .searchable(text: $searchText, prompt: "코인 이름으로 검색하세요")

--- a/AIProject/AIProject/Features/Search/SearchView.swift
+++ b/AIProject/AIProject/Features/Search/SearchView.swift
@@ -16,7 +16,7 @@ struct SearchView: View {
             if searchText.isEmpty {
                 RecentSearchView(viewModel: viewModel)
             } else {
-                RelatedKeywordView(viewModel: viewModel)
+            	RelatedKeywordView(viewModel: viewModel)
             }
         }
         .searchable(text: $searchText, prompt: "코인 이름으로 검색하세요")

--- a/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
+++ b/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AsyncAlgorithms
 
 final class SearchViewModel: ObservableObject {
-    @Published var bookMarkCoins: [Coin] = []
+    @Published var recentSearchCoins: [Coin] = []
     @Published var relatedCoins: [Coin] = []
 
     private var upbitService: UpBitAPIService
@@ -25,13 +25,14 @@ final class SearchViewModel: ObservableObject {
         observeStream()
     }
     
-    /// 북마크에 저장된 코인을 받아옵니다.
-    func loadBookMarkCoins() {
-        bookMarkCoins = [
-            Coin(id: "KRW-BTC", koreanName: "비트코인"),
-            Coin(id: "KRW-ETC", koreanName: "이더리움"),
-            Coin(id: "KRW-LTC", koreanName: "리트코인"),
-        ]
+    /// 최근 검색 기록을 받아옵니다.
+    func loadRecentSearchKeyword() {
+        guard let recentSearchCoins = UserDefaults.standard.array(forKey: "recentSearchCoins") as? [Data] else {
+            recentSearchCoins = []
+			return
+        }
+
+        self.recentSearchCoins = recentSearchCoins.compactMap { $0.toCoin }
     }
     
     /// 검색 키워드를 스트림에 전달합니다.

--- a/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
+++ b/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
@@ -66,7 +66,7 @@ final class SearchViewModel: ObservableObject {
     private func setupCoinData() {
         Task {
             do {
-                let coinDTOs = try await upbitService.fetchMarkets()
+                let coinDTOs = try await upbitService.fetchMarkets().filter { $0.coinID.contains("KRW") }
                 coins = coinDTOs.map { Coin(id: $0.coinID, koreanName: $0.koreanName) }
             } catch {
                 print(error.localizedDescription)

--- a/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
+++ b/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
@@ -35,9 +35,9 @@ final class SearchViewModel: ObservableObject {
         self.recentSearchCoins = recentSearchCoins.compactMap { $0.toCoin }
     }
     
-    /// 최근 검색 기록에 추가합니다.
+    /// 최근 검색 기록에 업데이트합니다.
     /// - Parameter coin: 추가할 코인 데이터입니다.
-    func addRecentSearchKeyword(_ coin: Coin) {
+    func updateRecentSearchKeyword(_ coin: Coin) {
         if recentSearchCoins.contains(where: { $0.id == coin.id }) {
             removeRecentSearchKeyword(coin)
         }
@@ -66,7 +66,7 @@ final class SearchViewModel: ObservableObject {
     private func setupCoinData() {
         Task {
             do {
-                let coinDTOs = try await upbitService.fetchMarkets().filter { $0.coinID.contains("KRW") }
+                let coinDTOs = try await upbitService.fetchMarkets()
                 coins = coinDTOs.map { Coin(id: $0.coinID, koreanName: $0.koreanName) }
             } catch {
                 print(error.localizedDescription)

--- a/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
+++ b/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
@@ -96,7 +96,7 @@ final class SearchViewModel: ObservableObject {
     private func performSearch(with keyword: String) {
         guard !keyword.isEmpty else { return }
 
-        relatedCoins = coins.filter { $0.koreanName.contains(keyword) }
+        relatedCoins = coins.filter { $0.koreanName.contains(keyword) || $0.id.lowercased().contains(keyword.lowercased()) }
     }
 
     deinit {

--- a/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
+++ b/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
@@ -35,6 +35,27 @@ final class SearchViewModel: ObservableObject {
         self.recentSearchCoins = recentSearchCoins.compactMap { $0.toCoin }
     }
     
+    /// 최근 검색 기록에 추가합니다.
+    /// - Parameter coin: 추가할 코인 데이터입니다.
+    func addRecentSearchKeyword(_ coin: Coin) {
+        if recentSearchCoins.contains(where: { $0.id == coin.id }) {
+            removeRecentSearchKeyword(coin)
+        }
+
+        recentSearchCoins.insert(coin, at: 0)
+        UserDefaults.standard.set(recentSearchCoins.compactMap { $0.toData }, forKey: "recentSearchCoins")
+    }
+
+    
+    /// 최근 검색 기록을 삭제합니다.
+    /// - Parameter coin: 삭제할 코인 데이터입니다.
+    func removeRecentSearchKeyword(_ coin: Coin) {
+        if let index = recentSearchCoins.firstIndex(where: { $0.id == coin.id }) {
+            recentSearchCoins.remove(at: index)
+            UserDefaults.standard.set(recentSearchCoins.compactMap { $0.toData }, forKey: "recentSearchCoins")
+        }
+    }
+
     /// 검색 키워드를 스트림에 전달합니다.
     /// - Parameter keyword: 사용자가 입력한 검색어 문자열입니다.
     func sendKeyword(with keyword: String) async {

--- a/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
+++ b/AIProject/AIProject/Features/Search/ViewModel/SearchViewModel.swift
@@ -1,0 +1,84 @@
+//
+//  SearchViewModel.swift
+//  AIProject
+//
+//  Created by 강대훈 on 8/5/25.
+//
+
+import SwiftUI
+import AsyncAlgorithms
+
+final class SearchViewModel: ObservableObject {
+    @Published var bookMarkCoins: [Coin] = []
+    @Published var relatedCoins: [Coin] = []
+
+    private var upbitService: UpBitAPIService
+
+    private var coins: [Coin] = []
+
+    private var continuation: AsyncStream<String>.Continuation?
+    private var task: Task<Void, Never>?
+
+    init() {
+        upbitService = UpBitAPIService()
+        setupCoinData()
+        observeStream()
+    }
+    
+    /// 북마크에 저장된 코인을 받아옵니다.
+    func loadBookMarkCoins() {
+        bookMarkCoins = [
+            Coin(id: "KRW-BTC", koreanName: "비트코인"),
+            Coin(id: "KRW-ETC", koreanName: "이더리움"),
+            Coin(id: "KRW-LTC", koreanName: "리트코인"),
+        ]
+    }
+    
+    /// 검색 키워드를 스트림에 전달합니다.
+    /// - Parameter keyword: 사용자가 입력한 검색어 문자열입니다.
+    func sendKeyword(with keyword: String) async {
+        continuation?.yield(keyword)
+    }
+
+    /// 업비트에 존재하는 모든 코인 목록을 받아옵니다.
+    private func setupCoinData() {
+        Task {
+            do {
+                let coinDTOs = try await upbitService.fetchMarkets()
+                coins = coinDTOs.map { Coin(id: $0.coinID, koreanName: $0.koreanName) }
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+
+    /// 사용자 검색어 스트림을 관찰하고 검색을 트리거합니다.
+    ///
+    /// - 해당 메소드는 0.3초의 디바운스가 적용되어 있습니다.
+    private func observeStream() {
+        let stream = AsyncStream<String> { continuation in
+            self.continuation = continuation
+        }
+
+        task = Task {
+            for await keyword in stream.removeDuplicates().debounce(for: .seconds(0.3)) {
+                await performSearch(with: keyword)
+            }
+        }
+    }
+
+    /// 주어진 키워드를 기반으로 관련 코인 목록을 필터링하여 갱신합니다.
+    ///
+    /// - Parameter keyword: 사용자가 입력한 검색어입니다.
+    @MainActor
+    private func performSearch(with keyword: String) {
+        guard !keyword.isEmpty else { return }
+
+        relatedCoins = coins.filter { $0.koreanName.contains(keyword) }
+    }
+
+    deinit {
+        task?.cancel()
+        task = nil
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> #16 #17 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> - swift-async-algorithm 패키지 추가
> - 검색 UI
> - 검색 로직
> - 디바운스 적용

---
화면은 다음과 같이 구성했고 검색창에 입력하게 되면 화면을 분기해서 보여주도록 구현했습니다.

<img width="1451" height="598" alt="image" src="https://github.com/user-attachments/assets/e676f63e-1991-43d8-a733-22beb40c318b" />

---
- `UserDefaults` 를 활용하여 **최근 검색 기록을 저장했습니다.** 
- `UserDefaults` 에는 사용자 정의 타입을 저장할 수 없어서 `Data` 타입으로 인코딩하여 저장했습니다.

```swift
/// SearchViewModel
// 로드
func loadRecentSearchKeyword()
/// 추가
func addRecentSearchKeyword(_ coin: Coin)
// 삭제
func removeRecentSearchKeyword(_ coin: Coin)
```

---
- 검색에 디바운스를 적용했습니다.

`swift-async-algorithms` 라이브러리를 추가해서 적용했습니다. `AsyncStream` 에서 지원하는 것을 확인하고 다음과 같이 구현했습니다.
https://developer.apple.com/videos/play/wwdc2022/110355/

```swift
private func observeStream() {
    let stream = AsyncStream<String> { continuation in
        self.continuation = continuation
    }

    task = Task {
        // debounce(for:) -> 0.3초의 디바운스 적용
        // removeDuplicates() -> 중복된 데이터 제거
        for await keyword in stream.removeDuplicates().debounce(for: .seconds(0.3)) {
            await performSearch(with: keyword)
        }
    }
}
```

데이터는 다음 메소드로 스트림했습니다.
```swift
func sendKeyword(with keyword: String) async {
    continuation?.yield(keyword)
}
```

---

### 스크린샷
- UI는 와이어프레임을 참고했습니다!

https://github.com/user-attachments/assets/98586976-75f6-4384-97e3-e60cc97925e5

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - `swift-async-algorithms` 가 잘 포함되어 있는지 확인 부탁드립니다! (`.pbxproj`, `Package.resolved`는 확인했습니다.)
> - 코인 데이터를 받아오는 코드가 있는데 `UpBitService` 에 구현하는게 맞을까요?
```swift
private func setupCoinData() {
    Task {
        do {
            let coinDTOs = try await upbitService.fetchMarkets().filter { $0.coinID.contains("KRW") }
            coins = coinDTOs.map { Coin(id: $0.coinID, koreanName: $0.koreanName) }
        } catch {
            print(error.localizedDescription)
        }
    }
}
```

---

### 2차 수정
- 뷰가 많아짐에 따라서 분리했습니다.
- 검색에 맞는 데이터가 없을 경우에 대체 뷰를 띄우도록 구현했습니다.
- `KRW-ETC` 와 같이 `coinID` 로도 검색이 가능하도록 추가했습니다.

테스트 영상도 변경되었으니 참고해주시면 될 거 같습니다!