### PR TITLE
Fix: 현재가 시세 적용

### DIFF
--- a/AIProject/AIProject/Features/Market/CoinListView.swift
+++ b/AIProject/AIProject/Features/Market/CoinListView.swift
@@ -23,8 +23,8 @@ struct CoinListView: View {
                     
                     // Geometry가 레이아웃이 바뀌면 rerender를 발동시켜서 소켓 명령어를 다시 실행시켜서 크래쉬 발생
                     GeometryReader { geometry in
-                        CoinCell(coin: coin)
                         ZStack {
+                            CoinCell(coin: coin)
                             NavigationLink {
                                 CoinDetailView(coin: Coin(id: coin.id, koreanName: coin.name))
                             } label: {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
- #106 
- #80 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Navigation Disclosure 제거
- 현재가 시세 적용

### 스크린샷 (선택)
<img width="30%" alt="image" src="https://github.com/user-attachments/assets/0554dc3a-e009-4a41-ae1f-84b11ec36c26" />
<img width="30%"  alt="IMG_6482" src="https://github.com/user-attachments/assets/ec4c71b3-6f5e-48b0-baae-44ac98129bd0" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
### 문제점
- 스크롤 하는대로 티켓을 새로 발행해서 너무 많은 요청으로 웹소켓이 죽어버립니다. throttle을 이용해서 다음 PR때 해결하겠습니다.
- 죽은 웹소켓 reconnect하는 로직도 다음 PR때 넣겠습니다. 이외 버그 같은 게 있다면 알려주세요
