### PR TITLE
대시보드 - AI 브리핑 전체 시장 분위기, 커뮤니티 분위기

### DIFF
--- a/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
@@ -144,4 +144,25 @@ extension AlanAPIService {
             throw error
         }
     }
+    
+    /// 하루 동안의 커뮤니티 동향을 JSON 형식으로 가져옵니다.
+    func fetchCommunityInsight(from post: String) async throws -> CommunityInsightDTO {
+        let prompt = Prompt.generateCommunityInsight(redditPost: post)
+        let answer = try await fetchAnswer(content: prompt.content, action: .coinReportGeneration)
+        print(answer.content)
+        
+        guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "extractedJSON 문자열을 UTF-8 데이터로 변환하는 데 실패했습니다."
+                )
+            )
+        }
+        do {
+            return try JSONDecoder().decode(CommunityInsightDTO.self, from: jsonData)
+        } catch {
+            throw error
+        }
+    }
 }

--- a/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
@@ -80,6 +80,27 @@ extension AlanAPIService {
             throw error
         }
     }
+    
+    /// 일주일간의 가격 추이 및 거래량 변화 정보를 JSON 형식으로 가져옵니다.
+    func fetchWeeklyTrends(for coin: Coin) async throws -> CoinWeeklyDTO {
+        let prompt = Prompt.generateWeeklyTrends(coinKName: coin.koreanName)
+        let answer = try await fetchAnswer(content: prompt.content, action: .coinReportGeneration)
+        print(answer.content)
+        
+        guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "extractedJSON 문자열을 UTF-8 데이터로 변환하는 데 실패했습니다."
+                )
+            )
+        }
+        do {
+            return try JSONDecoder().decode(CoinWeeklyDTO.self, from: jsonData)
+        } catch {
+            throw error
+        }
+    }
 
     /// 최근 24시간 뉴스 기반 시장 분위기와 기사 목록을 JSON 형식으로 가져옵니다.
     func fetchTodayNews(for coin: Coin) async throws -> CoinTodayNewsDTO {
@@ -98,27 +119,6 @@ extension AlanAPIService {
         
         do {
             return try JSONDecoder().decode(CoinTodayNewsDTO.self, from: jsonData)
-        } catch {
-            throw error
-        }
-    }
-
-    /// 일주일간의 가격 추이 및 거래량 변화 정보를 JSON 형식으로 가져옵니다.
-    func fetchWeeklyTrends(for coin: Coin) async throws -> CoinWeeklyDTO {
-        let prompt = Prompt.generateWeeklyTrends(coinKName: coin.koreanName)
-        let answer = try await fetchAnswer(content: prompt.content, action: .coinReportGeneration)
-        print(answer.content)
-        
-        guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: [],
-                    debugDescription: "extractedJSON 문자열을 UTF-8 데이터로 변환하는 데 실패했습니다."
-                )
-            )
-        }
-        do {
-            return try JSONDecoder().decode(CoinWeeklyDTO.self, from: jsonData)
         } catch {
             throw error
         }

--- a/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
@@ -123,4 +123,25 @@ extension AlanAPIService {
             throw error
         }
     }
+    
+    /// 2시간 동안의 전체 시장 정보를 JSON 형식으로 가져옵니다.
+    func fetchTodayInsight() async throws -> TodayInsightDTO {
+        let prompt = Prompt.generateTodayInsight
+        let answer = try await fetchAnswer(content: prompt.content, action: .coinReportGeneration)
+        print(answer.content)
+        
+        guard let jsonData = answer.content.extractedJSON.data(using: .utf8) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "extractedJSON 문자열을 UTF-8 데이터로 변환하는 데 실패했습니다."
+                )
+            )
+        }
+        do {
+            return try JSONDecoder().decode(TodayInsightDTO.self, from: jsonData)
+        } catch {
+            throw error
+        }
+    }
 }

--- a/AIProject/AIProject/Core/Remote/APIService/RedditAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/RedditAPIService.swift
@@ -11,7 +11,7 @@ import Foundation
 /// 레딧 API 관련 서비스를 제공합니다.
 final class RedditAPIService {
     private let network: NetworkClient
-    private let endpoint: String = "https://oauth.reddit.com/r/cryptocurrency/top.json?t=day&limit=20"
+    private let endpoint: String = "https://oauth.reddit.com/r/cryptocurrency/top.json?t=day&limit=5"
 
     init(networkClient: NetworkClient = .init()) {
         self.network = networkClient

--- a/AIProject/AIProject/Data/Model/FearGreed.swift
+++ b/AIProject/AIProject/Data/Model/FearGreed.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 
+/// 공포-탐욕 지수를 나타내는 열거형입니다.
+///
+/// 이 열거형은 암호화폐 시장의 심리를 다섯 단계로 분류합니다.
+/// 각 단계는 색상(`color`)과 설명(`description`)을 제공합니다.
 enum FearGreed: String {
     case extremeFear = "Extreme Fear"
     case fear = "Fear"
@@ -14,6 +18,7 @@ enum FearGreed: String {
     case greed = "Greed"
     case extremeGreed = "Extreme Greed"
     
+    /// 지수 단계에 따라 시각적으로 표현할 색상을 반환합니다.
     var color: Color {
         switch self {
         case .extremeFear:
@@ -29,6 +34,7 @@ enum FearGreed: String {
         }
     }
     
+    /// 각 지수 단계에 대한 한글 설명을 제공합니다.
     var description: String {
         switch self {
         case .extremeFear:
@@ -46,6 +52,10 @@ enum FearGreed: String {
 }
 
 extension FearGreed {
+    /// 문자열로부터 `FearGreed` 열거형 값을 생성합니다.
+    ///
+    /// - Parameter classification: "Extreme Fear", "Fear" 등과 같은 문자열 값
+    /// - Returns: 해당 문자열에 대응하는 `FearGreed` 값. 알 수 없는 문자열은 `.neutral`을 반환합니다.
     static func from(_ classification: String) -> FearGreed {
         switch classification {
         case "Extreme Fear":

--- a/AIProject/AIProject/Data/Model/FearGreed.swift
+++ b/AIProject/AIProject/Data/Model/FearGreed.swift
@@ -44,3 +44,22 @@ enum FearGreed: String {
         }
     }
 }
+
+extension FearGreed {
+    static func from(_ classification: String) -> FearGreed {
+        switch classification {
+        case "Extreme Fear":
+            return .extremeFear
+        case "Fear":
+            return .fear
+        case "Neutral":
+            return .neutral
+        case "Greed":
+            return .greed
+        case "Extreme Greed":
+            return .extremeGreed
+        default:
+            return .neutral
+        }
+    }
+}

--- a/AIProject/AIProject/Data/Model/Prompt.swift
+++ b/AIProject/AIProject/Data/Model/Prompt.swift
@@ -12,6 +12,7 @@ enum Prompt {
     case generateTodayNews(coinKName: String)
     case generateWeeklyTrends(coinKName: String)
     case extractCoinID(text: String)
+    case generateTodayInsight
 
     var content: String {
         switch self {
@@ -83,6 +84,23 @@ enum Prompt {
             """
             아래의 문자열 배열에서 가상화폐의 이름을 찾아. 응답에는 다른 설명 없이 `[]` 이런 빈 배열에 영문 심볼들만 담아서 반환해. 오타가 있다면 고쳐주고 "," 로 구분해.
             \(text)
+            """
+        case.generateTodayInsight:
+            """
+            struct TodayInsightDTO: Codable {
+                /// 주어진 시간 동안의 암호화폐 전체 시장 분위기 (호재 / 악재 / 중립)
+                let todaysSentiment: String
+                
+                /// 내용 요약
+                /// 호재의 경우 긍정요인만 or 악재라면 부정 요인만 제공
+                /// 중립이라면 긍정요인, 부정요인을 같이 담은 [String]을 제공
+                let summary: [String: [String]]
+            }
+
+            1. 현재 국내 시간을 기준으로 최근 2시간 뉴스 기반
+            2. 뉴스 전반을 분석해 시장 분위기를 요약 
+
+            위 조건에 따라 암호화폐 전체 시장에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
             """
         }
     }

--- a/AIProject/AIProject/Data/Model/Prompt.swift
+++ b/AIProject/AIProject/Data/Model/Prompt.swift
@@ -13,6 +13,7 @@ enum Prompt {
     case generateWeeklyTrends(coinKName: String)
     case extractCoinID(text: String)
     case generateTodayInsight
+    case generateCommunityInsight(redditPost: String)
 
     var content: String {
         switch self {
@@ -101,6 +102,18 @@ enum Prompt {
             2. 뉴스 전반을 분석해 시장 분위기를 요약 
 
             위 조건에 따라 암호화폐 전체 시장에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
+            """
+        case.generateCommunityInsight(let redditPost):
+            """
+            \(redditPost)
+            지금 보낸 건, reddit의 r/CryptoCurrecy community에서, 하루동안 좋아요를 가장 많이 받은 게시물 5개의 제목과 내용이야.
+            이 게시물들을 TodayInsightDTO를 기반으로 JSON으로 응답해줘.
+            struct CommunityInsightDTO: Codable {
+                /// 게시물을 기반으로 평가한 커뮤니티 분위기 (호재 / 악재 / 중립)
+                let todaysSentiment: String
+                /// 커뮤니티 분위기를 그렇게 평가한 이유 요약
+                let summary: String
+            }
             """
         }
     }

--- a/AIProject/AIProject/Data/Model/Sentiment.swift
+++ b/AIProject/AIProject/Data/Model/Sentiment.swift
@@ -7,11 +7,16 @@
 
 import SwiftUI
 
+/// 시장에 대한 감정(Sentiment)을 분류하는 열거형입니다.
+///
+/// 이 열거형은 긍정적, 중립적, 부정적 세 가지 시장 감정을 나타냅니다.
+/// 각 케이스는 색상(`color`)과 설명(`description`)을 제공합니다.
 enum Sentiment {
     case positive
     case neutral
     case negative
     
+    /// 시장 감정에 따라 시각적으로 표현할 색상을 반환합니다.
     var color: Color {
         switch self {
         case .positive:
@@ -23,6 +28,7 @@ enum Sentiment {
         }
     }
     
+    /// 각 감정에 대한 한글 설명을 제공합니다.
     var description: String {
         switch self {
         case .positive: return "호재"
@@ -33,6 +39,10 @@ enum Sentiment {
 }
 
 extension Sentiment {
+    /// 문자열로부터 `Sentiment` 값을 생성합니다.
+    ///
+    /// - Parameter string: "호재", "악재", "중립" 등과 같은 문자열 값
+    /// - Returns: 해당 문자열에 대응하는 `Sentiment` 값. 알 수 없는 문자열은 `.neutral`을 반환합니다.
     static func from(_ string: String) -> Sentiment {
         switch string {
         case "호재": return .positive

--- a/AIProject/AIProject/Data/Model/Sentiment.swift
+++ b/AIProject/AIProject/Data/Model/Sentiment.swift
@@ -13,21 +13,32 @@ enum Sentiment {
     case negative
     
     var color: Color {
-            switch self {
-            case .positive:
-                return .aiCoPositive
-            case .negative:
-                return .aiCoNegative
-            case .neutral:
-                return .gray // FIXME: 중립 색상 만들기
-            }
+        switch self {
+        case .positive:
+            return .aiCoPositive
+        case .negative:
+            return .aiCoNegative
+        case .neutral:
+            return .gray // FIXME: 중립 색상 만들기
         }
+    }
+    
+    var description: String {
+        switch self {
+        case .positive: return "호재"
+        case .negative: return "악재"
+        case .neutral: return "중립"
+        }
+    }
+}
 
-        var description: String {
-            switch self {
-            case .positive: return "호재"
-            case .negative: return "악재"
-            case .neutral: return "중립"
-            }
+extension Sentiment {
+    static func from(_ string: String) -> Sentiment {
+        switch string {
+        case "호재": return .positive
+        case "중립": return .neutral
+        case "악재": return .negative
+        default: return .neutral // TODO: 새로고침 버튼 만들기
         }
+    }
 }

--- a/AIProject/AIProject/Data/Response/AlanResponse/Content/CommunityInsightDTO.swift
+++ b/AIProject/AIProject/Data/Response/AlanResponse/Content/CommunityInsightDTO.swift
@@ -1,0 +1,16 @@
+//
+//  CommunityInsightDTO.swift
+//  AIProject
+//
+//  Created by 장지현 on 8/7/25.
+//
+
+import Foundation
+
+struct CommunityInsightDTO: Codable {
+    /// 게시물을 기반으로 평가한 커뮤니티 분위기 (호재 / 악재 / 중립)
+    let todaysSentiment: String
+    
+    /// 평가 이유
+    let summary: String
+}

--- a/AIProject/AIProject/Data/Response/AlanResponse/Content/TodayInsightDTO.swift
+++ b/AIProject/AIProject/Data/Response/AlanResponse/Content/TodayInsightDTO.swift
@@ -1,0 +1,16 @@
+//
+//  TodayInsightDTO.swift
+//  AIProject
+//
+//  Created by 장지현 on 8/6/25.
+//
+
+import Foundation
+
+struct TodayInsightDTO: Codable {
+    /// 오늘 암호화폐 전체 시장 분위기 (호재 / 악재 / 중립)
+    let todaysSentiment: String
+    
+    /// 내용 요약
+    let summary: [String: [String]]
+}

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -18,13 +18,13 @@ struct ReportView: View {
         ScrollView() {
             VStack(spacing: 0) {
                 ReportSectionView(title: "한눈에 보는 \(viewModel.koreanName)", contents: [viewModel.coinOverView])
-                // FIXME: 웹사이트 정보를 지우거나, 웹사이트로 이동할 수 있는 버튼 만들기
+                // TODO: 웹사이트 정보를 지우거나, 웹사이트로 이동할 수 있는 버튼 만들기
+                
+                ReportSectionView(title: "주간 동향 확인", contents: [viewModel.coinWeeklyTrends])
                 
                 ReportSectionView(title: "오늘 시장 분위기 살펴보기", contents: [viewModel.coinTodayTrends])
                 
                 ReportNewsSectionView(title: "주요 뉴스", articles: viewModel.coinTodayTopNews, isNews: true)
-                
-                ReportSectionView(title: "주간 동향 확인", contents: [viewModel.coinWeeklyTrends])
             }
         }
         .padding(.top, 15)

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
@@ -24,8 +24,8 @@ final class ReportViewModel: ObservableObject {
         
         Task.detached(priority: .background) {
             await self.fetchOverViewAsync()
-            await self.fetchTodayTopNewsAsync()
             await self.fetchWeeklyTrendsAsync()
+            await self.fetchTodayTopNewsAsync()
         }
     }
     
@@ -50,22 +50,6 @@ final class ReportViewModel: ObservableObject {
         }
     }
     
-    private func fetchTodayTopNewsAsync() async {
-        do {
-            let data = try await alanAPIService.fetchTodayNews(for: coin)
-            await MainActor.run {
-                self.coinTodayTrends = data.summaryOfTodaysMarketSentiment
-                self.coinTodayTopNews = data.articles.map { CoinArticle(from: $0) }
-            }
-        } catch {
-            print("오류 발생: \(error.localizedDescription)")
-            await MainActor.run {
-                self.coinTodayTrends = "데이터를 불러오는 데 실패했어요"
-                self.coinTodayTopNews = [CoinArticle(title: "데이터를 불러오는데 실패했어요", summary: "", url: "")]
-            }
-        }
-    }
-    
     private func fetchWeeklyTrendsAsync() async {
         do {
             let data = try await alanAPIService.fetchWeeklyTrends(for: coin)
@@ -82,6 +66,22 @@ final class ReportViewModel: ObservableObject {
             print("오류 발생: \(error.localizedDescription)")
             await MainActor.run {
                 self.coinWeeklyTrends = "데이터를 불러오는 데 실패했어요"
+            }
+        }
+    }
+    
+    private func fetchTodayTopNewsAsync() async {
+        do {
+            let data = try await alanAPIService.fetchTodayNews(for: coin)
+            await MainActor.run {
+                self.coinTodayTrends = data.summaryOfTodaysMarketSentiment
+                self.coinTodayTopNews = data.articles.map { CoinArticle(from: $0) }
+            }
+        } catch {
+            print("오류 발생: \(error.localizedDescription)")
+            await MainActor.run {
+                self.coinTodayTrends = "데이터를 불러오는 데 실패했어요"
+                self.coinTodayTopNews = [CoinArticle(title: "데이터를 불러오는데 실패했어요", summary: "", url: "")]
             }
         }
     }

--- a/AIProject/AIProject/Features/Dashboard/View/DashboardSectionView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/DashboardSectionView.swift
@@ -17,8 +17,7 @@ struct DashboardSectionView<Content: View>: View {
             SubheaderView(subheading: subheading, description: description)
             content()
         }
-        .padding(.bottom, 40
-        )
+        .padding(.bottom, 40)
     }
 }
 

--- a/AIProject/AIProject/Features/Dashboard/View/TodayCoinInsightView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/TodayCoinInsightView.swift
@@ -31,6 +31,7 @@ struct TodayCoinInsightView: View {
         }
         .font(.system(size: 13))
         .padding(.horizontal)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/FearGreedViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/FearGreedViewModel.swift
@@ -7,9 +7,15 @@
 
 import Foundation
 
+/// 공포-탐욕 지수를 관리하는 뷰 모델입니다.
+///
+/// API에서 데이터를 받아 공포 탐욕 지수 수치와 설명을 업데이트합니다.
 final class FearGreedViewModel: ObservableObject {
+    /// 공포-탐욕 상태입니다.
     @Published var fearGreed: FearGreed = .neutral
+    /// 공포-탐욕 지수 값입니다.
     @Published var indexValue: CGFloat = 0
+    /// 한글로 표시된 공포-탐욕 분류입니다.
     @Published var classification: String = "중립"
     
     init() {
@@ -18,6 +24,7 @@ final class FearGreedViewModel: ObservableObject {
         }
     }
     
+    /// 공포-탐욕 지수 데이터를 불러와 상태를 업데이트합니다.
     private func fetchFearGreedAsync() async {
         do {
             let data = try await FearGreedAPIService().fetchData()

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/FearGreedViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/FearGreedViewModel.swift
@@ -34,20 +34,7 @@ final class FearGreedViewModel: ObservableObject {
             
             await MainActor.run {
                 self.indexValue = CGFloat(doubleIndex)
-                switch fearGreedIndex.valueClassification {
-                case "Extreme Fear":
-                    fearGreed = .extremeFear
-                case "Fear":
-                    fearGreed = .fear
-                case "Neutral":
-                    fearGreed = .neutral
-                case "Greed":
-                    fearGreed = .greed
-                case "Extreme Greed":
-                    fearGreed = .extremeGreed
-                default:
-                    print("Fear And Greed Index: Invalid valueClassification")
-                }
+                fearGreed = FearGreed.from(fearGreedIndex.valueClassification)
                 self.classification = fearGreed.description
             }
         } catch {

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
@@ -7,10 +7,17 @@
 
 import Foundation
 
+/// 오늘의 코인 시장/커뮤니티 인사이트를 제공하는 뷰 모델입니다.
+///
+/// AI 또는 커뮤니티 기반의 인사이트를 비동기적으로 불러오고,
+/// 감정(Sentiment)과 요약(summary)을 제공합니다.
 final class TodayCoinInsightViewModel: ObservableObject {
+    /// AI가 분석한 감정 결과입니다.
     @Published var sentiment: Sentiment = .neutral
+    /// AI 또는 커뮤니티 기반의 요약 내용입니다.
     @Published var summary: String = "AI가 정보를 준비하고 있어요"
     
+    /// 커뮤니티 기반 인사이트인지 여부입니다.
     let isCommunity: Bool
     let alanAPIService = AlanAPIService()
     let redditAPIService = RedditAPIService()
@@ -22,6 +29,7 @@ final class TodayCoinInsightViewModel: ObservableObject {
         }
     }
     
+    /// AI 기반의 전체 인사이트를 비동기적으로 가져옵니다.
     private func fetchOverallAsync() async {
         do {
             let data = try await alanAPIService.fetchTodayInsight()
@@ -48,6 +56,9 @@ final class TodayCoinInsightViewModel: ObservableObject {
         }
     }
     
+    /// 커뮤니티 기반 인사이트를 비동기적으로 가져옵니다.
+    ///
+    /// Reddit에서 데이터를 수집하고, 해당 내용을 요약 요청하여 감정과 요약을 설정합니다.
     private func fetchCommunityAsync() async {
         do {
             let communityData = try await redditAPIService.fetchData()

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
@@ -8,14 +8,11 @@
 import Foundation
 
 final class TodayCoinInsightViewModel: ObservableObject {
-    @Published var sentiment: Sentiment = .positive
-    @Published var summary: String = """
-    비트코인은 약 $114,900~115,000 수준에서 반등하며 강세 흐름을 이어가고 있고, 이더리움 역시 최근 상승세를 보이며 투자자 심리를 지지하고 있습니다.
-    연준의 금리 인하 기대가 커지면서 달러 약세 및 위험자산 선호로 전체적으로 긍정적인 투자 분위기가 조성되고 있습니다.
-    다만, 이더리움에 대한 기관 자금 유입이 활발한 상황에서 스테이킹 관련 규제와 시장 변동성은 여전히 주의 요인입니다.
-    """
+    @Published var sentiment: Sentiment = .neutral
+    @Published var summary: String = "AI가 정보를 준비하고 있어요"
     
     let isCommunity: Bool
+    let alanAPIService = AlanAPIService()
     
     init(isCommunity: Bool = false) {
         self.isCommunity = isCommunity
@@ -25,7 +22,41 @@ final class TodayCoinInsightViewModel: ObservableObject {
     }
     
     private func fetchOverallAsync() async {
-        
+        do {
+            let data = try await alanAPIService.fetchTodayInsight()
+            await MainActor.run {
+                switch data.todaysSentiment {
+                case "호재":
+                    sentiment = .positive
+                case "중립":
+                    sentiment = .neutral
+                case "악재":
+                    sentiment = .negative
+                default:
+                    sentiment = .neutral
+                    // TODO: 새로고침
+                }
+                
+                self.summary = ""
+                
+                for (key, values) in data.summary {
+                    if data.summary.count > 1 {
+                        self.summary.append("‣ \(key) 소식\n")
+                    }
+                    for value in values {
+                        self.summary.append("\(value)\n")
+                    }
+                }
+                
+                self.summary = self.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+                print(self.summary)
+            }
+        } catch {
+            print("오류 발생: \(error.localizedDescription)")
+            await MainActor.run {
+                self.summary = "데이터를 불러오는 데 실패했어요"
+            }
+        }
     }
     
     private func fetchCommunityAsync() async {

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
@@ -25,32 +25,20 @@ final class TodayCoinInsightViewModel: ObservableObject {
     private func fetchOverallAsync() async {
         do {
             let data = try await alanAPIService.fetchTodayInsight()
+            
             await MainActor.run {
-                switch data.todaysSentiment {
-                case "호재":
-                    sentiment = .positive
-                case "중립":
-                    sentiment = .neutral
-                case "악재":
-                    sentiment = .negative
-                default:
-                    sentiment = .neutral
-                    // TODO: 새로고침
-                }
+                sentiment = Sentiment.from(data.todaysSentiment)
                 
-                self.summary = ""
-                
-                for (key, values) in data.summary {
+                self.summary = data.summary.map { key, values in
+                    var content = ""
                     if data.summary.count > 1 {
-                        self.summary.append("‣ \(key) 소식\n")
+                        content += "‣ \(key) 소식\n"
                     }
-                    for value in values {
-                        self.summary.append("\(value)\n")
-                    }
+                    content += values.joined(separator: "\n")
+                    return content
                 }
-                
-                self.summary = self.summary.trimmingCharacters(in: .whitespacesAndNewlines)
-                print(self.summary)
+                .joined(separator: "\n\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             }
         } catch {
             print("오류 발생: \(error.localizedDescription)")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- #32 
- #33 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 대시보드에서 AI 브리핑: 전체 시장, 커뮤니티 분위기 작업했습니다.
- 전체 시장 분위기는 2시간 동안의 뉴스를 기반으로 앨런을 통해 콘텐츠를 구성합니다.
- 커뮤니티 분위기
    - reddit의 r/cryptocurrency 커뮤니티에서 하루 동안 좋아요를 많이 받은 게시물 5개를 받아옵니다.
    - 받아온 게시물의 제목과 내용을 기반으로 앨런을 통해 콘텐츠를 구성합니다.
- ReportView의 콘텐츠 순서를 뉴스가 가장 아래로 가도록 수정했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- Alan API의 fetch method들이 중복되는 코드가 많아서 다음 스프린트 때 리팩토링 해 볼 예정입니다.
- 게시물의 내용이 길다면 프롬프트의 길이가 길어지는데, 다음 스프린트에서 네트워크 에러에 메세지가 긴 경우 추가 후 대응할 예정입니다.