### PR TITLE
코인 상세 정보 화면 - 라인 차트에서 캔들 차트로 변경

### DIFF
--- a/AIProject/AIProject/Core/Remote/APIService/UpbitAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/UpbitAPIService.swift
@@ -66,8 +66,16 @@ final class UpBitAPIService {
     ///   - market: 조회할 마켓 코드 (ex. "RKW-BTC")
     ///   - count: 가져올 캔들 데이터 개수, 기본값은 1입니다.
     /// - Returns: 해당 코인(마켓)의 1분 단위의 캔들 정보
-    func fetchCandles(id market: String, count: Int = 1) async throws -> [MinuteCandleDTO] {
-        let urlString = "\(endpoint)/candles/minutes/1?market=\(market)&count=\(count)"
+    func fetchCandles(id market: String, count: Int = 1, to: Date? = nil) async throws -> [MinuteCandleDTO] {
+        var urlString = "\(endpoint)/candles/minutes/1?market=\(market)&count=\(count)"
+        
+        if let to = to {
+            let formatter = ISO8601DateFormatter()
+            formatter.timeZone = TimeZone(identifier: "UTC")
+            let toString = formatter.string(from: to)
+            urlString += "&to=\(toString)"
+        }
+        
         guard let url = URL(string: urlString) else { throw NetworkError.invalidURL }
         let minuteCandleDTOs: [MinuteCandleDTO] = try await network.request(url: url)
 

--- a/AIProject/AIProject/Core/Remote/APIService/UpbitPriceService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/UpbitPriceService.swift
@@ -13,21 +13,44 @@ import Foundation
 /// UpBitAPIService를 뷰모델에서 사용할 수 있도록 하는 어댑터 역할
 final class UpbitPriceService: CoinPriceProvider {
     private let api: UpBitAPIService
+    private let candleLimit = 200
     
     init(api: UpBitAPIService = .init()) {
         self.api = api
     }
     
-    func fetchPrices(market: String, interval: CoinInterval) async throws -> [CoinPrice] {
-        let count = interval.candleCount
+    /// 지정된 마켓과 기간에 따라 시세 데이터를 반복 호출을 통해 수집하고 `CoinPrice` 배열로 반환
+    /// - Parameters:
+    ///   - market: 마켓 식별자 (예: "KRW-BTC")
+    ///   - interval: 가져올 데이터의 기간 정보 (분 단위)
+    ///   - to: 데이터를 가져올 종료 시점 (기본적으로 현재 시각 기준)
+    /// - Returns: 변환된 `CoinPrice` 배열
+    func fetchPrices(market: String, interval: CoinInterval, to: Date?) async throws -> [CoinPrice] {
+        var allCandles: [MinuteCandleDTO] = []
+        var toDate = interval.endDate
         
-        let DTOs = try await api.fetchCandles(id: market, count: count)
-        
-        let prices = DTOs.map { dto in
-            CoinPrice(date: dto.tradeDateTime, close: dto.tradePrice)
+        while allCandles.count < interval.minutes {
+            let count = min(candleLimit, interval.minutes - allCandles.count)
+            let newCandles = try await api.fetchCandles(id: market, count: count, to: toDate)
+            
+            guard !newCandles.isEmpty else { break }
+            
+            allCandles += newCandles
+            toDate = newCandles.last!.tradeDateTime.addingTimeInterval(-60)  // 1분 이전으로 이동
         }
-        .sorted(by: { $0.date < $1.date })
         
-        return prices
+        return allCandles
+            .reversed()
+            .enumerated()
+            .map { idx, dto in
+                CoinPrice(
+                    date: dto.tradeDateTime,
+                    open: dto.openingPrice,
+                    high: dto.highPrice,
+                    low: dto.lowPrice,
+                    close: dto.tradePrice,
+                    index: idx
+                )
+            }
     }
 }

--- a/AIProject/AIProject/Data/Model/CoinInterval.swift
+++ b/AIProject/AIProject/Data/Model/CoinInterval.swift
@@ -7,31 +7,28 @@
 
 import Foundation
 
-/// 코인 차트의 기간 선택 옵션
-/// `rawValue`는 UI 표시용 문자열 (예: "1D") 이며, `Identifiable`의 `id`로도 재사용
-enum CoinInterval: String, CaseIterable, Identifiable {
-    /// 1일
-    case d1 = "1D"
-    /// 1주
-    case w1 = "1W"
-    /// 3개월
-    case m3 = "3M"
-    /// 6개월
-    case m6 = "6M"
-    /// 1년
-    case y1 = "1Y"
-    
-    /// UI 및 리스트 바인딩을 위한 고유 식별자
-    var id: String { rawValue }
-    
-    /// 각 기간별로 차트에 필요한 캔들(데이터 포인트) 수를 반환
-    var candleCount: Int {
-        switch self {
-        case .d1: return 60 * 24
-        case .w1: return 60 * 24 * 7
-        case .m3: return 60 * 24 * 30 * 3
-        case .m6: return 60 * 24 * 30 * 6
-        case .y1: return 60 * 24 * 365
-        }
+/// 코인 차트에서 기간을 나타내는 구조체 모델
+/// API 요청 시 필요한 시작 날짜 계산 및 구간 식별에 사용
+struct CoinInterval: Identifiable, Hashable {
+    /// 기간 ID (예: "1D", "1W" 등)
+    let id: String
+    /// 현재 시점을 기준으로 몇 분 전부터 데이터를 조회할지 나타내는 분 단위 값
+    let minutes: Int
+    /// 시작일 계산: 현재 시점에서 `minutes` 만큼 이전 시각
+    var startDate: Date {
+        Calendar.current.date(byAdding: .minute, value: -minutes, to: Date())!
     }
+    /// 종료일: 항상 현재 시각 기준
+    var endDate: Date {
+        Date()
+    }
+
+    /// 사용 가능한 전체 기간 옵션 목록
+    static let all: [CoinInterval] = [
+        CoinInterval(id: "1D", minutes: 1440), // 1일 == 1440분
+        CoinInterval(id: "1W", minutes: 1440 * 7),
+        CoinInterval(id: "3M", minutes: 1440 * 30 * 3),
+        CoinInterval(id: "6M", minutes: 1440 * 30 * 6),
+        CoinInterval(id: "1Y", minutes: 1440 * 365)
+    ]
 }

--- a/AIProject/AIProject/Data/Model/CoinPrice.swift
+++ b/AIProject/AIProject/Data/Model/CoinPrice.swift
@@ -9,12 +9,20 @@ import Foundation
 
 /// 코인 가격의 한 지점(시계열) 표현
 struct CoinPrice: Identifiable {
-    /// 데이터 시점 (차트 x축)
-    let date: Date
-    /// 해당 시점의 종가 (차트 y축)
-    let close: Double
     /// `date` 기반 고유 식별자
     var id: TimeInterval { date.timeIntervalSinceReferenceDate }
+    /// 데이터 시점 (차트 x축)
+    let date: Date
+    /// 해당 시점의 시가 (캔들 차트 기준 시작 가격)
+    let open: Double
+    /// 해당 시점의 고가 (해당 구간 내 최고 가격)
+    let high: Double
+    /// 해당 시점의 저가 (해당 구간 내 최저 가격)
+    let low: Double
+    /// 해당 시점의 종가 (캔들 차트 기준 종료 가격)
+    let close: Double
+    // 배열 내 인덱스 (선택 시 원래 순서 유지에 사용)
+    let index: Int
 }
 
 /// 차트 상단 표시에 사용하는 가격 요약 값

--- a/AIProject/AIProject/Data/Protocol/CoinPriceProvider.swift
+++ b/AIProject/AIProject/Data/Protocol/CoinPriceProvider.swift
@@ -14,6 +14,13 @@ protocol CoinPriceProvider {
     /// - Parameters:
     ///   - market: 마켓 식별자 (예: "KRW-BTC")
     ///   - interval: 가격 차트의 기간 옵션 (예: .d1 = 1일)
+    ///   - to: 종료 기준 시각 (기본: nil)
     /// - Returns: 시계열 가격 데이터 배열
-    func fetchPrices(market: String, interval: CoinInterval) async throws -> [CoinPrice]
+    func fetchPrices(market: String, interval: CoinInterval, to: Date?) async throws -> [CoinPrice]
+}
+
+extension CoinPriceProvider {
+    func fetchPrices(market: String, interval: CoinInterval) async throws -> [CoinPrice] {
+        try await fetchPrices(market: market, interval: interval, to: nil)
+    }
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -14,7 +14,7 @@ struct ChartView: View {
     /// 헤더/차트에 바인딩되는 상태를 관리하는 ViewModel
     @StateObject var viewModel: ChartViewModel
     /// 사용자 선택 기간 (현재는 1D만 표시, 나머지는 UI용)
-    @State private var selectedInterval: CoinInterval = .d1
+    @State private var selectedInterval: CoinInterval = CoinInterval.all.first!
     /// 세그먼트 탭 선택 인덱스 (커스텀 SegmentedControlView와 바인딩)
     @State private var selectedTab = 0
 
@@ -187,7 +187,7 @@ struct ChartView: View {
                 GeometryReader { proxy in
                     SegmentedControlView(
                         selection: $selectedTab,
-                        tabTitles: CoinInterval.allCases.map(\.rawValue),
+                        tabTitles: CoinInterval.all.map(\.id),
                         width: proxy.size.width
                     )
                     .frame(width: proxy.size.width, height: 44)

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -34,13 +34,13 @@ struct ChartView: View {
         let isRising = summary?.change ?? 0 > 0
         let isFalling = summary?.change ?? 0 < 0
         let color: Color = isRising ? .aiCoNegative :
-                           isFalling ? .aiCoPositive :
-                           .gray
+        isFalling ? .aiCoPositive :
+            .gray
         
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-
-                // 타이틀 영역: 코인명 / 심볼
+                
+                /// 타이틀 영역: 코인명 / 심볼
                 HStack(spacing: 8) {
                     Text(viewModel.coinName)
                         .font(.title3).bold()
@@ -184,6 +184,8 @@ struct ChartView: View {
                     plotArea
                         .padding(.trailing, 10)
                 }
+                
+                /// 기간 선택 탭 (UI용)
                 GeometryReader { proxy in
                     SegmentedControlView(
                         selection: $selectedTab,

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -28,6 +28,7 @@ struct ChartView: View {
     }
     
     var body: some View {
+        /// 차트 시계열 데이터에서 마지막 포인트 (가장 최신 데이터)
         let lastPoint = data.last
 
         let isRising = summary?.change ?? 0 > 0
@@ -81,50 +82,108 @@ struct ChartView: View {
                         .foregroundStyle(color)
                 }
                 
-                /// 값 차이가 작아도 차트가 납작하게 보이지 않도록 최소 높이와 여유 공간을 추가
-                let minY = data.map(\.close).min() ?? 0
-                let maxY = data.map(\.close).max() ?? 0
+                /// 시계열 데이터의 고가/저가를 기준으로 차트의 Y축 범위를 동적으로 계산
+                let minY = data.map(\.low).min() ?? 0
+                let maxY = data.map(\.high).max() ?? 0
+                
+                /// 값 차이가 너무 작을 경우 대비한 최소 범위 설정
                 let range = maxY - minY
                 let minRange: Double = 10
+                
+                /// 실제 시각화에 사용할 안전 범위 및 여유 공간 설정
                 let safeRange = max(range, minRange)
-                let padding = safeRange * 0.05
+                let padding = safeRange * 0.2
                 let center = (minY + maxY) / 2
-
-                /// 실제 적용할 차트 Y축 최소/최대값
+                
+                /// Y축 범위 설정 (중앙 기준 양방향 + 여유 padding)
                 let chartMin = center - safeRange / 2 - padding
                 let chartMax = center + safeRange / 2 + padding
                 
-                // 라인 차트: 가격 시계열 렌더링 + 마지막 포인트 하이라이트
-                Chart {
-                    ForEach(data) { point in
-                        LineMark(
-                            x: .value("Date", point.date),
-                            y: .value("Close", point.close)
-                        )
+                /// X축 도메인 설정을 위한 기준 시간 계산
+                let now = Date()
+                let calendar = Calendar(identifier: .gregorian)
+                
+                /// 차트 우측 여백 확보용 시간 (5분 후)
+                let futurePadding = TimeInterval(60 * 5)
+                
+                /// X축 시작은 오늘 00:00, 끝은 마지막 데이터 시점 + 5분
+                let lastDate = data.last?.date ?? now
+                let xStart = calendar.startOfDay(for: now)
+                let xEnd = lastDate.addingTimeInterval(futurePadding)
+                
+                /// 초기 스크롤 위치: 데이터의 가장 마지막 시간 이후로 약간 이동
+                let scrollTo = lastDate.addingTimeInterval(futurePadding)
+                
+                /// X축 시간 표시 포맷 (HH:mm / 24시간제)
+                let timeFormatter: DateFormatter = {
+                    let formatter = DateFormatter()
+                    formatter.dateFormat = "HH:mm"
+                    formatter.locale = Locale(identifier: "ko_KR")
+                    return formatter
+                }()
+                
+                /// 캔들 차트: 가격 시계열을 고가/저가 선(RuleMark) + 시가/종가 직사각형(RectangleMark)으로 표현
+                Chart(data) { point in
+                    /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
+                    RuleMark(
+                        x: .value("Date", point.date),
+                        yStart: .value("Low", point.low),
+                        yEnd: .value("High", point.high)
+                    )
+                    .foregroundStyle(point.close >= point.open ? .aiCoPositive : .aiCoNegative)
+                    
+                    /// 시가/종가 직사각형 (실체 바)
+                    RectangleMark(
+                        x: .value("Date", point.date),
+                        yStart: .value("Open", point.open),
+                        yEnd: .value("Close", point.close),
+                        width: 6
+                    )
+                    .foregroundStyle(point.close >= point.open ? .aiCoPositive : .aiCoNegative)
+                }
+                .frame(height: 380)
+                /// X축 도메인 설정 및 스크롤 위치 초기화
+                .chartXScale(domain: xStart...xEnd)
+                .chartScrollPosition(initialX: scrollTo)
+                .chartScrollableAxes(.horizontal)
+                /// Y축 도메인 설정 (동적 범위)
+                .chartYScale(domain: chartMin...chartMax)
+                /// 한 화면에서 보이는 X축 범위 (2880초 = 48분)
+                .chartXVisibleDomain(length: 2880)
+                /// X축 눈금 (15분 간격) + 1시간마다 세로선 표시
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .minute, count: 15)) { value in
+                        AxisTick()
+                        AxisValueLabel {
+                            if let date = value.as(Date.self) {
+                                Text(timeFormatter.string(from: date))
+                            }
+                        }
+                        
+                        // 세로선은 1시간 단위(분 == 0)일 때만 표시
+                        if let date = value.as(Date.self),
+                           Calendar.current.component(.minute, from: date) == 0 {
+                            AxisGridLine()
+                        }
                     }
-                    .interpolationMethod(.catmullRom)
-                    .lineStyle(StrokeStyle(lineWidth: 3))
-                    .foregroundStyle(color)
-
-                    if let last = lastPoint {
-                        PointMark(
-                            x: .value("Date", last.date),
-                            y: .value("Close", last.close)
-                        )
-                        .symbol {
-                            ZStack {
-                                Circle().fill(color.opacity(0.12)).frame(width: 36, height: 36)
-                                Circle().fill(color).frame(width: 10, height: 10)
+                }
+                /// Y축 눈금 (20만 원 단위) + 값 포맷을 M(억) 단위로 축약
+                .chartYAxis {
+                    AxisMarks(values: .stride(by: 200_000)) { value in // 20만원 단위 눈금 표시
+                        AxisGridLine()
+                        AxisTick()
+                        if let price = value.as(Double.self) {
+                            AxisValueLabel {
+                                Text(String(format: "%.1fM", price / 1_000_000))
                             }
                         }
                     }
                 }
-                .frame(height: 380)
-                .chartYScale(domain: chartMin...chartMax)
-                .chartXAxis(.hidden)
-                .chartYAxis(.hidden)
-
-                // 기간 선택 탭 (UI용)
+                /// 차트 오른쪽 영역에 여백 추가
+                .chartPlotStyle { plotArea in
+                    plotArea
+                        .padding(.trailing, 10)
+                }
                 GeometryReader { proxy in
                     SegmentedControlView(
                         selection: $selectedTab,

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -71,13 +71,13 @@ struct ChartView: View {
 
                 // 상단 요약: 현재가 및 등락
                 if let summary {
-                    Text(summary.lastPrice, format: .currency(code: viewModel.currency))
+                    Text("\(summary.lastPrice.formatted(.number.grouping(.automatic)))원")
                         .font(.largeTitle).bold()
                         .foregroundStyle(.aiCoLabel)
                     
                     let sign = isRising ? "+" : (isFalling ? "-" : "")
                     
-                    Text("\(sign)\(abs(summary.change), format: .currency(code: viewModel.currency)) (\(summary.changeRate, format: .number.precision(.fractionLength(1)))%)")
+                    Text("\(sign)\(abs(summary.change).formatted(.number.grouping(.automatic)))원 (\(summary.changeRate, format: .number.precision(.fractionLength(1)))%)")
                         .font(.subheadline)
                         .foregroundStyle(color)
                 }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -74,6 +74,16 @@ final class ChartViewModel: ObservableObject {
             let marketCode = coinSymbol
             let fetchedPrices = try await priceService.fetchPrices(market: marketCode, interval: interval)
             self.prices = fetchedPrices
+            self.prices = fetchedPrices.enumerated().map { idx, price in
+                CoinPrice(
+                    date: price.date,
+                    open: price.open,
+                    high: price.high,
+                    low: price.low,
+                    close: price.close,
+                    index: idx
+                )
+            }
         } catch {
             print("가격 불러오기 실패: \(error.localizedDescription)")
             self.prices = []


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## 📝 작업 내용

- 라인 차트를 캔들 차트로 변경하여 더 정밀한 가격 흐름이 보이도록 개선
- Upbit API가 한 번에 최대 200개 캔들만 내려주는 제한이 있음 (가장 최근 시점부터 과거로 200개) 
-> 200개가 넘는 오늘 자정(`8/7 00:00`) ~ 오늘 현재 시각(예. `8/7 18:00`) 범위를 조회하려면 반복 호출이 필요 
  1. 가장 먼저 최신 시간 기준으로 200개 받음
  2. 그 다음 가장 오래된 캔들의 시간을 확인하고
  3. 그 시간을 to로 지정해서, 그 시간 이전의 200개를 다시 요청 
  4. 또 가장 오래된 시간을 to로 지정해서 반복…   

  -> `UpbitAPIService`의 `fetchCandles` 메서드에 `to` 파라미터를 추가해 반복 호출 방식으로 해결 
   - `fetchCandles(market:interval:)` → 최신 200개만 가능
  - `fetchCandles(market:interval:to:)` → 원하는 시점부터 과거 200개 가능
 
- Upbit API 응답 시간이 `UTC`기준이라 오늘 날짜(`KST` 기준)가 포함되지 않는 문제가 있음 -> `KST`기준으로 오늘까지만 필터링 처리
- 차트에 표시되는 통화 단위를 "₩" 기호 대신 "원"으로 변경하여 앱 텍스트가 한글로 통일되도록 수정

### 스크린샷 (선택)
<img height="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-07 at 13 43 16" src="https://github.com/user-attachments/assets/12f5cee0-39ec-4dcb-a648-dff274d58d34" />
<img height="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-07 at 18 02 59" src="https://github.com/user-attachments/assets/1ca7fad2-fd99-4ca7-8932-1ac4f57fce51" />

## 💬 리뷰 요구사항(선택)
