### PR TITLE
ThemeManager의 UserDefaults 키를 AppStorageKey enum으로 관리

### DIFF
--- a/AIProject/AIProject/Data/Model/AppStorageKey.swift
+++ b/AIProject/AIProject/Data/Model/AppStorageKey.swift
@@ -9,4 +9,5 @@ import Foundation
 
 enum AppStorageKey {
     static let investmentType = "investmentType"
+    static let theme = "selectedTheme"
 }

--- a/AIProject/AIProject/Features/MyPage/View/Theme/ThemeManager.swift
+++ b/AIProject/AIProject/Features/MyPage/View/Theme/ThemeManager.swift
@@ -17,13 +17,10 @@ class ThemeManager: ObservableObject {
         }
     }
     
-    /// UserDefaults에 저장할 키 값
-    private let themeKey = "selectedTheme"
-    
     /// 초기화 시 저장된 테마 값을 UserDefaults에서 불러와 설정
     /// 저장된 값이 없거나 변환에 실패할 경우 기본 테마인 `.basic`을 사용
     init() {
-        if let saved = UserDefaults.standard.string(forKey: themeKey),
+        if let saved = UserDefaults.standard.string(forKey: AppStorageKey.theme),
            let theme = Theme(rawValue: saved) {
             self.selectedTheme = theme
         } else {
@@ -33,6 +30,6 @@ class ThemeManager: ObservableObject {
     
     /// 선택된 테마를 UserDefaults에 저장
     private func saveTheme() {
-        UserDefaults.standard.set(selectedTheme.rawValue, forKey: themeKey)
+        UserDefaults.standard.set(selectedTheme.rawValue, forKey: AppStorageKey.theme)
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #158 

## 📝 작업 내용

- ThemeManager에서 하드코딩된 UserDefaults 키("selectedTheme")를 AppStorageKey enum으로 이동
- UserDefaults 접근 시 AppStorageKey.theme를 사용하도록 수정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 리뷰가 필요한 부분은 없습니다! 
key 이름만 괜찮다면 approve 해주세요~
     ```Swift
     static let theme = "selectedTheme"
     ```
