### PR TITLE
clientID가 비어있을 때 처리

### DIFF
--- a/AIProject/AIProject/Core/Network/NetworkError.swift
+++ b/AIProject/AIProject/Core/Network/NetworkError.swift
@@ -52,9 +52,9 @@ extension NetworkError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .taskCancelled:
-            return "작업이 취소되었습니다. 아래 버튼을 눌러 다시 시도해 주세요."
+            return "작업이 취소됐어요"
         default:
-            return "데이터를 불러오는 데 실패했어요. 잠시 후 다시 시도해 주세요."
+            return "데이터를 불러오지 못했어요\n잠시 후 다시 시도해 주세요"
         }
     }
 }
@@ -77,7 +77,7 @@ extension NetworkError {
                     .dataCorrupted(let context):
                 message = context.debugDescription
             @unknown default:
-                message = "알 수 없는 디코딩 오류입니다."
+                message = "알 수 없는 디코딩 오류입니다"
             }
             let escaped = message.replacingOccurrences(of: "\"", with: "\\\"")
             return "decodingError(\"\(escaped)\")-\"\(file)#\(function)\""

--- a/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/AlanAPIService.swift
@@ -20,7 +20,7 @@ final class AlanAPIService {
     /// - Parameter content: 질문 또는 분석할 문장
     /// - Returns: 수신한 응답 데이터
     func fetchAnswer(content: String, action: AlanAction) async throws -> AlanResponseDTO {
-        guard let clientID = switchClientID(for: action) else { throw NetworkError.invalidAPIKey }
+        guard let clientID = switchClientID(for: action), !clientID.isEmpty else { throw NetworkError.invalidAPIKey }
         
         let urlString = "\(endpoint)?content=\(content)&client_id=\(clientID)"
         guard let url = URL(string: urlString) else { throw NetworkError.invalidURL }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- Alan 요청에서 clientID가 비어있는 경우 401로 처리되는 문제를 해결하였습니다.
    - NetworkError.invalidAPIKey를 던지도록 추가했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
