### PR TITLE
ChartView, 코인별 차트 뷰 디자인 적용

### DIFF
--- a/AIProject/AIProject/Core/Remote/APIService/UpbitPriceService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/UpbitPriceService.swift
@@ -49,6 +49,7 @@ final class UpbitPriceService: CoinPriceProvider {
                     high: dto.highPrice,
                     low: dto.lowPrice,
                     close: dto.tradePrice,
+                    tradeValue: dto.candleAccTradePrice,
                     index: idx
                 )
             }

--- a/AIProject/AIProject/Core/Remote/APIService/UpbitPriceService.swift
+++ b/AIProject/AIProject/Core/Remote/APIService/UpbitPriceService.swift
@@ -49,7 +49,7 @@ final class UpbitPriceService: CoinPriceProvider {
                     high: dto.highPrice,
                     low: dto.lowPrice,
                     close: dto.tradePrice,
-                    tradeValue: dto.candleAccTradePrice,
+                    trade: dto.candleAccTradePrice,
                     index: idx
                 )
             }

--- a/AIProject/AIProject/Data/Model/CoinPrice.swift
+++ b/AIProject/AIProject/Data/Model/CoinPrice.swift
@@ -21,6 +21,8 @@ struct CoinPrice: Identifiable {
     let low: Double
     /// 해당 시점의 종가 (캔들 차트 기준 종료 가격)
     let close: Double
+    /// 해당 시점의 거래대금
+    let tradeValue: Double
     // 배열 내 인덱스 (선택 시 원래 순서 유지에 사용)
     let index: Int
 }

--- a/AIProject/AIProject/Data/Model/CoinPrice.swift
+++ b/AIProject/AIProject/Data/Model/CoinPrice.swift
@@ -22,7 +22,7 @@ struct CoinPrice: Identifiable {
     /// 해당 시점의 종가 (캔들 차트 기준 종료 가격)
     let close: Double
     /// 해당 시점의 거래대금
-    let tradeValue: Double
+    let trade: Double
     // 배열 내 인덱스 (선택 시 원래 순서 유지에 사용)
     let index: Int
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -95,77 +95,87 @@ struct ChartView: View {
                 }
             }
             
-            let yRange = viewModel.yAxisRange(from: data)
-            let xDomain = viewModel.xAxisDomain(for: data)
-            let scrollTo = viewModel.scrollToTime(for: data)
+            let chartRatio: CGFloat = 1.7
             
-            /// 캔들 차트: 가격 시계열을 고가/저가 선(RuleMark) + 시가/종가 직사각형(RectangleMark)으로 표현
-            Chart(data) { point in
-                /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
-                RuleMark(
-                    x: .value("Date", point.date),
-                    yStart: .value("Low", point.low),
-                    yEnd: .value("High", point.high)
-                )
-                .foregroundStyle(
-                    point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
-                )
-                
-                /// 시가/종가 직사각형 (실체 바)
-                RectangleMark(
-                    x: .value("Date", point.date),
-                    yStart: .value("Open", point.open),
-                    yEnd: .value("Close", point.close),
-                    width: 6
-                )
-                .foregroundStyle(
-                    point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
-                )
-            }
-            .padding(.vertical, 40)
-            .frame(height: 380)
-            /// X축 도메인 설정 및 스크롤 위치 초기화
-            .chartXScale(domain: xDomain)
-            .chartScrollPosition(initialX: scrollTo)
-            .chartScrollableAxes(.horizontal)
-            /// Y축 도메인 설정 (동적 범위)
-            .chartYScale(domain: yRange)
-            /// 한 화면에서 보이는 X축 범위 (2880초 = 48분)
-            .chartXVisibleDomain(length: 2880)
-            /// X축 눈금 (15분 간격) + 1시간마다 세로선 표시
-            .chartXAxis {
-                AxisMarks(values: .stride(by: .minute, count: 15)) { value in
-                    AxisTick()
-                    AxisValueLabel {
-                        if let date = value.as(Date.self) {
-                            Text(viewModel.timeFormatter.string(from: date))
-                        }
-                    }
+            ZStack {
+                if data.isEmpty {
+                    DefaultProgressView(message: "차트를 불러오는 중이에요")
+                } else {
+                    let yRange = viewModel.yAxisRange(from: data)
+                    let xDomain = viewModel.xAxisDomain(for: data)
+                    let scrollTo = viewModel.scrollToTime(for: data)
                     
-                    // 세로선은 1시간 단위(분 == 0)일 때만 표시
-                    if let date = value.as(Date.self),
-                       Calendar.current.component(.minute, from: date) == 0 {
-                        AxisGridLine()
+                    /// 캔들 차트: 가격 시계열을 고가/저가 선(RuleMark) + 시가/종가 직사각형(RectangleMark)으로 표현
+                    Chart(data) { point in
+                        /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
+                        RuleMark(
+                            x: .value("Date", point.date),
+                            yStart: .value("Low", point.low),
+                            yEnd: .value("High", point.high)
+                        )
+                        .foregroundStyle(
+                            point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
+                        )
+                        
+                        /// 시가/종가 직사각형 (실체 바)
+                        RectangleMark(
+                            x: .value("Date", point.date),
+                            yStart: .value("Open", point.open),
+                            yEnd: .value("Close", point.close),
+                            width: 6
+                        )
+                        .foregroundStyle(
+                            point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
+                        )
                     }
-                }
-            }
-            /// Y축 눈금 (20만 원 단위) + 값 포맷을 M(억) 단위로 축약
-            .chartYAxis {
-                AxisMarks(values: .stride(by: 200_000)) { value in // 20만원 단위 눈금 표시
-                    AxisGridLine()
-                    AxisTick()
-                    if let price = value.as(Double.self) {
-                        AxisValueLabel {
-                            Text(String(format: "%.1fM", price / 1_000_000))
+                    /// X축 도메인 설정 및 스크롤 위치 초기화
+                    .chartXScale(domain: xDomain)
+                    .chartScrollPosition(initialX: scrollTo)
+                    .chartScrollableAxes(.horizontal)
+                    /// Y축 도메인 설정 (동적 범위)
+                    .chartYScale(domain: yRange)
+                    /// 한 화면에서 보이는 X축 범위 (2880초 = 48분)
+                    .chartXVisibleDomain(length: 2880)
+                    /// X축 눈금 (15분 간격) + 1시간마다 세로선 표시
+                    .chartXAxis {
+                        AxisMarks(values: .stride(by: .minute, count: 15)) { value in
+                            AxisTick()
+                            AxisValueLabel {
+                                if let date = value.as(Date.self) {
+                                    Text(viewModel.timeFormatter.string(from: date))
+                                }
+                            }
+                            
+                            // 세로선은 1시간 단위(분 == 0)일 때만 표시
+                            if let date = value.as(Date.self),
+                               Calendar.current.component(.minute, from: date) == 0 {
+                                AxisGridLine()
+                            }
                         }
                     }
+                    /// Y축 눈금 (20만 원 단위) + 값 포맷을 M(억) 단위로 축약
+                    .chartYAxis {
+                        AxisMarks(values: .stride(by: 200_000)) { value in // 20만원 단위 눈금 표시
+                            AxisGridLine()
+                            AxisTick()
+                            if let price = value.as(Double.self) {
+                                AxisValueLabel {
+                                    Text(String(format: "%.1fM", price / 1_000_000))
+                                }
+                            }
+                        }
+                    }
+                    /// 차트 오른쪽 영역에 여백 추가
+                    .chartPlotStyle { plotArea in
+                        plotArea
+                            .padding(.trailing, 10)
+                            .padding(.bottom, 8) 
+                    }
                 }
             }
-            /// 차트 오른쪽 영역에 여백 추가
-            .chartPlotStyle { plotArea in
-                plotArea
-                    .padding(.trailing, 10)
-            }
+            .padding(.top, 40)
+            .padding(.bottom, 20)
+            .frame(height: 380)
         }
         .padding(20)
         .onAppear {

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -41,147 +41,144 @@ struct ChartView: View {
         isFalling ? themeManager.selectedTheme.negativeColor :
             .gray
         
-        ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 12) {
+            /// 타이틀 영역: 코인명 / 심볼
+            HStack(spacing: 8) {
+                Text(viewModel.coinName)
+                    .font(.title3).bold()
+                    .foregroundStyle(.aiCoLabel)
                 
-                /// 타이틀 영역: 코인명 / 심볼
-                HStack(spacing: 8) {
-                    Text(viewModel.coinName)
-                        .font(.title3).bold()
-                        .foregroundStyle(.aiCoLabel)
-
-                    CoinLabelView(text: viewModel.coinSymbol)
-                    
-                    Spacer()
-                    
-                    /// 코인 북마크 버튼
-                    /// - 현재 코인이 북마크되어 있는지 여부에 따라 아이콘 표시 변경
-                    /// - 탭 시 북마크 추가/제거 로직 호출
-                    Button(action: {
-                        viewModel.toggleBookmark()
-                    }) {
-                        ZStack {
-                            Circle()
-                                .fill(Color(.systemGray5))
-                                .frame(width: 32, height: 32)
-                            Image(systemName: viewModel.isBookmarked ? "bookmark.fill" : "bookmark")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 16, height: 16)
-                                .foregroundColor(.aiCoLabel)
-                        }
+                CoinLabelView(text: viewModel.coinSymbol)
+                
+                Spacer()
+                
+                /// 코인 북마크 버튼
+                /// - 현재 코인이 북마크되어 있는지 여부에 따라 아이콘 표시 변경
+                /// - 탭 시 북마크 추가/제거 로직 호출
+                Button(action: {
+                    viewModel.toggleBookmark()
+                }) {
+                    ZStack {
+                        Circle()
+                            .fill(Color(.systemGray5))
+                            .frame(width: 32, height: 32)
+                        Image(systemName: viewModel.isBookmarked ? "bookmark.fill" : "bookmark")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 16, height: 16)
+                            .foregroundColor(.aiCoLabel)
                     }
                 }
-
-                // 상단 요약: 현재가 및 등락
-                if let summary {
-                    Text(summary.lastPrice.formatKRW)
-                        .font(.largeTitle).bold()
-                        .foregroundStyle(.aiCoLabel)
-                    
-                    let sign = isRising ? "+" : (isFalling ? "-" : "")
-                    
-                    Text("\(sign)\(abs(summary.change).formatKRW) (\(summary.changeRate.formatRate))")
-                        .font(.subheadline)
-                        .foregroundStyle(color)
-                }
-                
-                let yRange = viewModel.yAxisRange(from: data)
-                let xDomain = viewModel.xAxisDomain(for: data)
-                let scrollTo = viewModel.scrollToTime(for: data)
-                
-                /// 캔들 차트: 가격 시계열을 고가/저가 선(RuleMark) + 시가/종가 직사각형(RectangleMark)으로 표현
-                Chart(data) { point in
-                    /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
-                    RuleMark(
-                        x: .value("Date", point.date),
-                        yStart: .value("Low", point.low),
-                        yEnd: .value("High", point.high)
-                    )
-                    .foregroundStyle(
-                        point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
-                    )
-                    
-                    /// 시가/종가 직사각형 (실체 바)
-                    RectangleMark(
-                        x: .value("Date", point.date),
-                        yStart: .value("Open", point.open),
-                        yEnd: .value("Close", point.close),
-                        width: 6
-                    )
-                    .foregroundStyle(
-                        point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
-                    )
-                }
-                .frame(height: 380)
-                /// X축 도메인 설정 및 스크롤 위치 초기화
-                .chartXScale(domain: xDomain)
-                .chartScrollPosition(initialX: scrollTo)
-                .chartScrollableAxes(.horizontal)
-                /// Y축 도메인 설정 (동적 범위)
-                .chartYScale(domain: yRange)
-                /// 한 화면에서 보이는 X축 범위 (2880초 = 48분)
-                .chartXVisibleDomain(length: 2880)
-                /// X축 눈금 (15분 간격) + 1시간마다 세로선 표시
-                .chartXAxis {
-                    AxisMarks(values: .stride(by: .minute, count: 15)) { value in
-                        AxisTick()
-                        AxisValueLabel {
-                            if let date = value.as(Date.self) {
-                                Text(viewModel.timeFormatter.string(from: date))
-                            }
-                        }
-                        
-                        // 세로선은 1시간 단위(분 == 0)일 때만 표시
-                        if let date = value.as(Date.self),
-                           Calendar.current.component(.minute, from: date) == 0 {
-                            AxisGridLine()
-                        }
-                    }
-                }
-                /// Y축 눈금 (20만 원 단위) + 값 포맷을 M(억) 단위로 축약
-                .chartYAxis {
-                    AxisMarks(values: .stride(by: 200_000)) { value in // 20만원 단위 눈금 표시
-                        AxisGridLine()
-                        AxisTick()
-                        if let price = value.as(Double.self) {
-                            AxisValueLabel {
-                                Text(String(format: "%.1fM", price / 1_000_000))
-                            }
-                        }
-                    }
-                }
-                /// 차트 오른쪽 영역에 여백 추가
-                .chartPlotStyle { plotArea in
-                    plotArea
-                        .padding(.trailing, 10)
-                }
-                
-                /// 기간 선택 탭 (UI용)
-                GeometryReader { proxy in
-                    SegmentedControlView(
-                        selection: $selectedTab,
-                        tabTitles: CoinInterval.all.map(\.id),
-                        width: proxy.size.width
-                    )
-                    .frame(width: proxy.size.width, height: 44)
-                }
-                .frame(height: 44)
             }
-            .padding(.horizontal, 20)
-            .padding(.top, 16)
-            /// 뷰가 나타날 때 현재 코인의 북마크 여부 확인 (PR 테스트용으로 남겨둠, 추후 삭제 예정)
-            .onAppear {
-                viewModel.checkBookmark()
-                do {
-                    let bookmarks = try BookmarkManager.shared.fetchAll()
-                    print("현재 북마크된 코인 목록:")
-                    for (idx, bookmark) in bookmarks.enumerated() {
-                        print("[\(idx)] \(bookmark.coinID ?? "<nil>") / \(bookmark.coinKoreanName ?? "<nil>")")
+            
+            // 상단 요약: 현재가 및 등락
+            if let summary {
+                Text(summary.lastPrice.formatKRW)
+                    .font(.largeTitle).bold()
+                    .foregroundStyle(.aiCoLabel)
+                
+                let sign = isRising ? "+" : (isFalling ? "-" : "")
+                
+                Text("\(sign)\(abs(summary.change).formatKRW) (\(summary.changeRate.formatRate))")
+                    .font(.subheadline)
+                    .foregroundStyle(color)
+            }
+            
+            let yRange = viewModel.yAxisRange(from: data)
+            let xDomain = viewModel.xAxisDomain(for: data)
+            let scrollTo = viewModel.scrollToTime(for: data)
+            
+            /// 캔들 차트: 가격 시계열을 고가/저가 선(RuleMark) + 시가/종가 직사각형(RectangleMark)으로 표현
+            Chart(data) { point in
+                /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
+                RuleMark(
+                    x: .value("Date", point.date),
+                    yStart: .value("Low", point.low),
+                    yEnd: .value("High", point.high)
+                )
+                .foregroundStyle(
+                    point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
+                )
+                
+                /// 시가/종가 직사각형 (실체 바)
+                RectangleMark(
+                    x: .value("Date", point.date),
+                    yStart: .value("Open", point.open),
+                    yEnd: .value("Close", point.close),
+                    width: 6
+                )
+                .foregroundStyle(
+                    point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
+                )
+            }
+            .frame(height: 380)
+            /// X축 도메인 설정 및 스크롤 위치 초기화
+            .chartXScale(domain: xDomain)
+            .chartScrollPosition(initialX: scrollTo)
+            .chartScrollableAxes(.horizontal)
+            /// Y축 도메인 설정 (동적 범위)
+            .chartYScale(domain: yRange)
+            /// 한 화면에서 보이는 X축 범위 (2880초 = 48분)
+            .chartXVisibleDomain(length: 2880)
+            /// X축 눈금 (15분 간격) + 1시간마다 세로선 표시
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .minute, count: 15)) { value in
+                    AxisTick()
+                    AxisValueLabel {
+                        if let date = value.as(Date.self) {
+                            Text(viewModel.timeFormatter.string(from: date))
+                        }
                     }
-                } catch {
-                    print("북마크 목록 가져오기 실패: \(error)")
+                    
+                    // 세로선은 1시간 단위(분 == 0)일 때만 표시
+                    if let date = value.as(Date.self),
+                       Calendar.current.component(.minute, from: date) == 0 {
+                        AxisGridLine()
+                    }
                 }
+            }
+            /// Y축 눈금 (20만 원 단위) + 값 포맷을 M(억) 단위로 축약
+            .chartYAxis {
+                AxisMarks(values: .stride(by: 200_000)) { value in // 20만원 단위 눈금 표시
+                    AxisGridLine()
+                    AxisTick()
+                    if let price = value.as(Double.self) {
+                        AxisValueLabel {
+                            Text(String(format: "%.1fM", price / 1_000_000))
+                        }
+                    }
+                }
+            }
+            /// 차트 오른쪽 영역에 여백 추가
+            .chartPlotStyle { plotArea in
+                plotArea
+                    .padding(.trailing, 10)
+            }
+            
+            /// 기간 선택 탭 (UI용)
+            GeometryReader { proxy in
+                SegmentedControlView(
+                    selection: $selectedTab,
+                    tabTitles: CoinInterval.all.map(\.id),
+                    width: proxy.size.width
+                )
+                .frame(width: proxy.size.width, height: 44)
+            }
+            .frame(height: 44)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 16)
+        /// 뷰가 나타날 때 현재 코인의 북마크 여부 확인 (PR 테스트용으로 남겨둠, 추후 삭제 예정)
+        .onAppear {
+            viewModel.checkBookmark()
+            do {
+                let bookmarks = try BookmarkManager.shared.fetchAll()
+                print("현재 북마크된 코인 목록:")
+                for (idx, bookmark) in bookmarks.enumerated() {
+                    print("[\(idx)] \(bookmark.coinID ?? "<nil>") / \(bookmark.coinKoreanName ?? "<nil>")")
+                }
+            } catch {
+                print("북마크 목록 가져오기 실패: \(error)")
             }
         }
         .background(.aiCoBackground)

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -91,7 +91,7 @@ struct ChartView: View {
                 Button(action: {
                     viewModel.toggleBookmark()
                 }) {
-                    CircleIconView(imageName: "bookmark")
+                    CircleIconView(imageName: viewModel.isBookmarked ? "bookmark.fill" : "bookmark")
                 }
             }
             

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -199,4 +199,5 @@ struct ChartView: View {
 
 #Preview {
     ChartView(coin: Coin(id: "KRW-BTC", koreanName: "비트코인"))
+        .environmentObject(ThemeManager())
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -81,9 +81,8 @@ struct ChartView: View {
                             .foregroundStyle(color)
                     }
                     
-                    let lastTradeValue = viewModel.prices.last?.tradeValue ?? 0
-                    
-                    Text("거래대금 \(lastTradeValue.formatMillion)")
+                    let trade = viewModel.prices.last?.trade ?? 0
+                    Text("거래대금 \(trade.formatMillion)")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(.aiCoLabelSecondary)
                 }

--- a/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
@@ -34,4 +34,5 @@ struct CoinDetailView: View {
 #Preview {
     let sampleCoin = Coin(id: "KRW-BTC", koreanName: "비트코인")
     CoinDetailView(coin: sampleCoin)
+        .environmentObject(ThemeManager())
 }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel+Dummy.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel+Dummy.swift
@@ -28,6 +28,7 @@ extension ChartViewModel {
             let close = value + Double.random(in: -2...2)
             let high = max(open, close) + Double.random(in: 0...1)
             let low = min(open, close) - Double.random(in: 0...1)
+            let tradeValue = Double.random(in: 50_000_000...200_000_000)
             
             priceSeries.append(
                 CoinPrice(
@@ -36,6 +37,7 @@ extension ChartViewModel {
                     high: high,
                     low: low,
                     close: close,
+                    tradeValue: tradeValue,
                     index: i
                 )
             )

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel+Dummy.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel+Dummy.swift
@@ -37,7 +37,7 @@ extension ChartViewModel {
                     high: high,
                     low: low,
                     close: close,
-                    tradeValue: tradeValue,
+                    trade: tradeValue,
                     index: i
                 )
             )

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -91,6 +91,7 @@ final class ChartViewModel: ObservableObject {
                     high: price.high,
                     low: price.low,
                     close: price.close,
+                    tradeValue: price.tradeValue,
                     index: idx
                 )
             }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -91,7 +91,7 @@ final class ChartViewModel: ObservableObject {
                     high: price.high,
                     low: price.low,
                     close: price.close,
-                    tradeValue: price.tradeValue,
+                    trade: price.trade,
                     index: idx
                 )
             }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #160 

## 📝 작업 내용

- 새 디자인 적용으로 UI 업데이트
  - 기준 시각과 거래대금 표시 기능 추가
  - 그래프 데이터가 없을 때 `DefaultProgressView` 표시 추가
  - 테스트용으로 남겨둔 로그 출력 코드(warning 발생 원인) 제거

### 스크린샷 (선택)
<img height="450" alt="스크린샷 2025-08-13 오전 12 59 24" src="https://github.com/user-attachments/assets/85d67e32-73ce-4eac-83c3-876a4b682327" />
<img  height="450" alt="스크린샷 2025-08-13 오전 1 17 35" src="https://github.com/user-attachments/assets/1e057137-cd9c-4e76-a0aa-e77860680532" />


## 💬 리뷰 요구사항(선택)

상위 뷰인 `CoinDetailView`에도 디자인 적용 예정이라, 현재 테스트 시에는 `ChartView` 단독으로 본 것과 다르게 나올 수 있습니다.
리뷰 시에는 `ChartView`의 프리뷰 화면 또는 첨부한 스크린샷을 기준으로 확인 부탁드립니다.
