### PR TITLE
SubheaderView 디자인 적용

### DIFF
--- a/AIProject/AIProject/Features/Base/SubheaderView.swift
+++ b/AIProject/AIProject/Features/Base/SubheaderView.swift
@@ -13,19 +13,19 @@ import SwiftUI
 ///   - imageName: 표시할 SF Symbol 아이콘 이름 (선택 사항)
 ///   - subheading: 서브헤더에 표시할 필수 제목
 ///   - description: 제목 아래에 표시할 설명 (선택 사항)
-///   - imageColor: 아이콘 색상 (기본값: `.aiCoAccent`) (선택 사항)
+///   - imageColor: 아이콘 색상 (기본값: `.aiCoAccent`)
 ///   - fontColor: 제목 및 설명 텍스트 색상 (기본값: `.aiCoLabel`)
 struct SubheaderView: View {
     var imageName: String?
     let subheading: String
     var description: String?
-    var imageColor: Color? = .aiCoAccent
+    var imageColor: Color = .aiCoAccent
     var fontColor: Color = .aiCoLabel
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 4) {
-                if let imageName, let imageColor {
+                if let imageName {
                     Image(systemName: imageName)
                         .font(.system(size: 19))
                         .foregroundStyle(imageColor)
@@ -48,12 +48,12 @@ struct SubheaderView: View {
 
 #Preview {
     SubheaderView(imageName: "sparkles", subheading: "이런 코인은 어떠세요?", description: "회원님의 관심 코인을 기반으로 새로운 코인을 추천해드려요", imageColor: .white, fontColor: .white)
-        .padding(16)
+        .padding(.vertical, 16)
         .background(.aiCoGradientAccentProminent)
     
     SubheaderView(subheading: "차트 색상 변경")
-        .padding(16)
+        .padding(.vertical, 16)
     
     SubheaderView(imageName: "sparkles", subheading: "북마크를 분석했어요")
-        .padding(16)
+        .padding(.vertical, 16)
 }

--- a/AIProject/AIProject/Features/Base/SubheaderView.swift
+++ b/AIProject/AIProject/Features/Base/SubheaderView.swift
@@ -7,22 +7,38 @@
 
 import SwiftUI
 
-/// 서브헤더에 표시할 제목을 필수로 전달해주세요.
-/// 제목 아래에 추가할 설명이 있다면 전달해주세요.
+/// 제목과 선택적 설명, 그리고 아이콘을 함께 표시하는 서브헤더 뷰입니다.
+///
+/// - Parameters:
+///   - imageName: 표시할 SF Symbol 아이콘 이름 (선택 사항)
+///   - subheading: 서브헤더에 표시할 필수 제목
+///   - description: 제목 아래에 표시할 설명 (선택 사항)
+///   - imageColor: 아이콘 색상 (기본값: `.aiCoAccent`) (선택 사항)
+///   - fontColor: 제목 및 설명 텍스트 색상 (기본값: `.aiCoLabel`)
 struct SubheaderView: View {
+    var imageName: String?
     let subheading: String
-    var description: String? = nil
+    var description: String?
+    var imageColor: Color? = .aiCoAccent
+    var fontColor: Color = .aiCoLabel
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(subheading)
-                .font(.system(size: 18, weight: .bold))
-                .foregroundStyle(.aiCoLabel)
-            
+            HStack(spacing: 4) {
+                if let imageName, let imageColor {
+                    Image(systemName: imageName)
+                        .font(.system(size: 19))
+                        .foregroundStyle(imageColor)
+                }
+                
+                Text(subheading)
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundStyle(fontColor)
+            }
             if let description {
                 Text(description)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.aiCoLabel)
+                    .font(.system(size: 15))
+                    .foregroundStyle(fontColor)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -31,5 +47,13 @@ struct SubheaderView: View {
 }
 
 #Preview {
-    SubheaderView(subheading: "이런 코인은 어떠세요?", description: "회원님의 관심 코인을 기반으로 새로운 코인을 추천해드려요")
+    SubheaderView(imageName: "sparkles", subheading: "이런 코인은 어떠세요?", description: "회원님의 관심 코인을 기반으로 새로운 코인을 추천해드려요", imageColor: .white, fontColor: .white)
+        .padding(16)
+        .background(.aiCoGradientAccentProminent)
+    
+    SubheaderView(subheading: "차트 색상 변경")
+        .padding(16)
+    
+    SubheaderView(imageName: "sparkles", subheading: "북마크를 분석했어요")
+        .padding(16)
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- #196 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 공통 SubheaderView에 디자인 적용했습니다.
    - imageName: SF Symbol 아이콘 이름 (선택)
    - subheading: 필수 제목 텍스트
    - description: 제목 아래 표시할 설명 (선택)
    - imageColor: 아이콘 색상, 기본값은 .aiCoAccent
    - fontColor: 제목 및 설명 텍스트 색상, 기본값은 .aiCoLabel

### 스크린샷 (선택)
<img width="404" height="250" alt="image" src="https://github.com/user-attachments/assets/f7330bf1-30cc-4ad1-97cf-ed59d9000610" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- 피그마보고 사용하는 뷰 모두 대응했는데, 혹시 놓친 부분이 있다면 말씀해주세요!