### PR TITLE
네트워크는 동시에 요청하고, UI 업데이트를 순차적으로 할 수 있게 수정

### DIFF
--- a/AIProject/AIProject/Data/Model/ResponseStatus.swift
+++ b/AIProject/AIProject/Data/Model/ResponseStatus.swift
@@ -7,9 +7,22 @@
 
 import SwiftUI
 
-enum ResponseStatus {
+enum ResponseStatus: Equatable {
     case loading
     case success
     case failure(NetworkError)
     case cancel(NetworkError)
+    
+    static func == (lhs: ResponseStatus, rhs: ResponseStatus) -> Bool {
+        switch (lhs, rhs) {
+        case (.loading, .loading),
+             (.success, .success):
+            return true
+        case (.failure, .failure),
+             (.cancel, .cancel):
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportNewsSectionView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportNewsSectionView.swift
@@ -41,11 +41,11 @@ struct ReportNewsSectionView: View {
                             
                             RoundedButton(title: "원문보기", imageName: "chevron.right") {
                                 // FIXME: 앨런에게서 뉴스 출처 url 받아오기
-//                                if let url = URL(string: article.newsSourceURL) {
-//                                    safariItem = IdentifiableURL(url: url)
-//                                }
-                                
-                                safariItem = IdentifiableURL(url: URL(string: "https://www.blockmedia.co.kr/archives/960242")!)
+                                if let url = URL(string: article.newsSourceURL) {
+                                    safariItem = IdentifiableURL(url: url)
+                                } else {
+                                    safariItem = IdentifiableURL(url: URL(string: "https://www.blockmedia.co.kr/archives/960242")!)
+                                }
                             }
                         }
                         

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -27,13 +27,13 @@ struct ReportView: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.aiCoNeutral)
                 
-                ReportSectionView(status: $viewModel.overviewStatus, imageName: "text.page.badge.magnifyingglass",title: "한눈에 보는 \(viewModel.koreanName)", content: viewModel.coinOverView)
+                ReportSectionView(status: $viewModel.overviewStatus, imageName: "text.page.badge.magnifyingglass",title: "한눈에 보는 \(viewModel.koreanName)", content: viewModel.coinOverView ?? "")
                 
-                ReportSectionView(status: $viewModel.weeklyStatus, imageName: "calendar", title: "주간 동향", content: AttributedString(viewModel.coinWeeklyTrends))
+                ReportSectionView(status: $viewModel.weeklyStatus, imageName: "calendar", title: "주간 동향", content: AttributedString(viewModel.coinWeeklyTrends ?? ""))
                 
-                ReportSectionView(status: $viewModel.todayStatus, imageName: "shareplay", title: "오늘 시장의 분위기", content: AttributedString(viewModel.coinTodayTrends))
+                ReportSectionView(status: $viewModel.todayStatus, imageName: "shareplay", title: "오늘 시장의 분위기", content: AttributedString(viewModel.coinTodayTrends ?? ""))
                 
-                ReportNewsSectionView(status: $viewModel.todayStatus, articles: viewModel.coinTodayTopNews)
+                ReportNewsSectionView(status: $viewModel.todayStatus, articles: viewModel.coinTodayTopNews ?? [])
             }
         }
     }

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -23,8 +23,6 @@ struct AIBriefingView: View {
             VStack(spacing: 16) {
                 TodayCoinInsightView()
                 
-                TodayCoinInsightView(isCommunity: true)
-                
                 FearGreedView()
                     .padding(.bottom, 30)
             }

--- a/AIProject/AIProject/Features/Dashboard/View/TodayCoinInsightView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/TodayCoinInsightView.swift
@@ -7,51 +7,31 @@
 
 import SwiftUI
 
-/// 오늘의 코인 시장 또는 커뮤니티 인사이트를 보여주는 뷰입니다.
+/// 오늘의 코인 시장과 커뮤니티 인사이트를 보여주는 뷰입니다.
 ///
 /// `TodayCoinInsightViewModel`을 사용해 감정 분석 결과와 요약 정보를 표시합니다.
-/// `isCommunity` 값에 따라 전체 시장 또는 커뮤니티 기반 인사이트를 구분하여 출력합니다.
-///
-/// - Parameters:
-///   - isCommunity: 커뮤니티 기반 인사이트 여부를 나타내는 불리언 값입니다.
 struct TodayCoinInsightView: View {
     @StateObject private var viewModel: TodayCoinInsightViewModel
     
-    let isCommunity: Bool
-    
-    init(isCommunity: Bool = false) {
-        self.isCommunity = isCommunity
-        _viewModel = StateObject(wrappedValue: TodayCoinInsightViewModel(isCommunity: isCommunity))
-    }
-    
-    // MARK: - Derived properties
-    private var statusBinding: Binding<ResponseStatus> {
-        isCommunity ? $viewModel.communityStatus : $viewModel.overviewStatus
-    }
-    
-    private var imageName: String {
-        isCommunity ? "shareplay" : "bitcoinsign.bank.building"
-    }
-    
-    private var title: String {
-        isCommunity ? "주요 커뮤니티의 분위기" : "전반적인 시장의 분위기"
-    }
-    
-    private var content: AttributedString {
-        AttributedString(viewModel.summary)
+    init() {
+        _viewModel = StateObject(wrappedValue: TodayCoinInsightViewModel())
     }
     
     var body: some View {
         ReportSectionView(
-            status: statusBinding,
-            imageName: imageName,
-            title: title,
-            sentiment: viewModel.sentiment,
-            content: content
+            status: $viewModel.overviewStatus,
+            imageName: "bitcoinsign.bank.building",
+            title: "전반적인 시장의 분위기",
+            sentiment: viewModel.overViewSentiment ?? nil,
+            content: AttributedString(viewModel.overViewSummary)
+        )
+        
+        ReportSectionView(
+            status: $viewModel.communityStatus,
+            imageName: "shareplay",
+            title: "주요 커뮤니티의 분위기",
+            sentiment: viewModel.communitySentiment ?? nil,
+            content: AttributedString(viewModel.communitySummary)
         )
     }
-}
-
-#Preview {
-    TodayCoinInsightView()
 }

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
@@ -36,16 +36,16 @@ final class TodayCoinInsightViewModel: ObservableObject {
             let data = try await alanAPIService.fetchTodayInsight()
             
             await MainActor.run {
-                self.overViewSentiment = Sentiment.from(data.todaysSentiment)
-                self.overViewSummary = data.summary
-                self.overviewStatus = .success
+                overViewSentiment = Sentiment.from(data.todaysSentiment)
+                overViewSummary = data.summary
+                overviewStatus = .success
             }
         } catch {
             guard let ne = error as? NetworkError else { return print(error) }
             
             print(ne.log())
             await MainActor.run {
-                self.overviewStatus = .failure(ne)
+                overviewStatus = .failure(ne)
             }
         }
     }
@@ -55,9 +55,9 @@ final class TodayCoinInsightViewModel: ObservableObject {
     /// Reddit에서 데이터를 수집하고, 해당 내용을 요약 요청하여 감정과 요약을 설정합니다.
     private func fetchCommunityAsync() async {
         do {
-            let communityData = try await redditAPIService.fetchData()
+            let redditData = try await redditAPIService.fetchData()
             
-            let communitySummary = communityData.enumerated().reduce(into: "") { result, element in
+            let redditSummary = redditData.enumerated().reduce(into: "") { result, element in
                 let (index, item) = element
                 
                 result += "제목\(index): \(item.data.title)"
@@ -68,14 +68,14 @@ final class TodayCoinInsightViewModel: ObservableObject {
             }
                 .trimmingCharacters(in: .newlines)
             
-            let alanData = try await alanAPIService.fetchCommunityInsight(from: communitySummary)
+            let alanData = try await alanAPIService.fetchCommunityInsight(from: redditSummary)
             
             await MainActor.run {
-                self.communitySentiment = Sentiment.from(alanData.todaysSentiment)
-                self.communitySummary = alanData.summary
+                communitySentiment = Sentiment.from(alanData.todaysSentiment)
+                communitySummary = alanData.summary
                 
-                if self.overviewStatus != .loading {
-                    self.communityStatus = .success
+                if overviewStatus != .loading {
+                    communityStatus = .success
                 }
             }
         } catch {
@@ -83,7 +83,7 @@ final class TodayCoinInsightViewModel: ObservableObject {
             
             print(ne.log())
             await MainActor.run {
-                self.communityStatus = .failure(ne)
+                communityStatus = .failure(ne)
             }
         }
     }

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/TodayCoinInsightViewModel.swift
@@ -22,6 +22,8 @@ final class TodayCoinInsightViewModel: ObservableObject {
     let alanAPIService = AlanAPIService()
     let redditAPIService = RedditAPIService()
     
+    private var pendingSentiment: Sentiment?
+    
     private var overallTask: Task<Void, Never>?
     private var communityTask: Task<Void, Never>?
     
@@ -39,6 +41,11 @@ final class TodayCoinInsightViewModel: ObservableObject {
                 overViewSentiment = Sentiment.from(data.todaysSentiment)
                 overViewSummary = data.summary
                 overviewStatus = .success
+                
+                if pendingSentiment != nil {
+                    communitySentiment = pendingSentiment
+                    communityStatus = .success
+                }
             }
         } catch {
             guard let ne = error as? NetworkError else { return print(error) }
@@ -71,10 +78,11 @@ final class TodayCoinInsightViewModel: ObservableObject {
             let alanData = try await alanAPIService.fetchCommunityInsight(from: redditSummary)
             
             await MainActor.run {
-                communitySentiment = Sentiment.from(alanData.todaysSentiment)
+                pendingSentiment = Sentiment.from(alanData.todaysSentiment)
                 communitySummary = alanData.summary
                 
                 if overviewStatus != .loading {
+                    communitySentiment = pendingSentiment
                     communityStatus = .success
                 }
             }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- #213 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 앨런에게 응답을 받아오는 시간을 줄일 수 있는 방법을 고민하다가, 네트워크는 동시에 요청하지만 순서대로 사용자에게 보여줄 수 있도록 DefaultProgressView가 사라지는 시점을 조절했습니다.
    - 브리핑, 리포트 모두 각 네트워크가 완료되었더라도 위에 있는 view의 업데이트 후 순차적으로 업데이트됩니다.

### 스크린샷 (선택)
|        | 대시보드 AI 브리핑 | 코인별 AI 리포트 |
|--------|--------------------|------------------|
| 일반   | <video src="https://github.com/user-attachments/assets/075cc063-8317-493d-bff9-3c6507685f39" controls muted playsinline width="320"></video> | <video src="https://github.com/user-attachments/assets/dbe0e633-4765-41da-897e-c006805c179f" controls muted playsinline width="320"></video> |
| 상위 view의 network를 sleep | <video src="https://github.com/user-attachments/assets/caf4db42-0ab0-4e1b-9169-fb1b1c6face5" controls muted playsinline width="320"></video> | <video src="https://github.com/user-attachments/assets/45e98ea5-64d2-490c-9b29-624f64aa671a" controls muted playsinline width="320"></video> |

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- 응답 시간을 줄이기 위해 해본 선택인데, 좋은 방향의 코드인지는 잘 모르겠습니다.