### PR TITLE
코인 상세 화면: 캔들 차트 1분봉 기간을 최근 24시간으로 수정

### DIFF
--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -38,18 +38,6 @@ struct ChartView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            /// 기간 선택 탭 (UI용)
-            GeometryReader { geometry in
-                SegmentedControlView(
-                    selection: $selectedTab,
-                    tabTitles: CoinInterval.all.map(\.id),
-                    width: geometry.size.width
-                )
-                .frame(width: geometry.size.width, height: 44)
-            }
-            .frame(height: 44)
-            .padding(.bottom, 20)
-            
             /// 타이틀 영역
             HStack(alignment: .top, spacing: 8) {
                 /// 기준 시간 / 현재가 / 등락가, 등락률 / 거래대금

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -77,11 +77,11 @@ final class ChartViewModel: ObservableObject {
             calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
 
             let nowKST = Date()
-            let todayStartKST = calendar.startOfDay(for: nowKST)
+            let last24hStartKST = nowKST.addingTimeInterval(-24 * 60 * 60)
 
             /// 당일 범위에 해당하는 가격만 필터링
             let filteredPrices = fetchedPrices.filter { price in
-                return price.date >= todayStartKST && price.date <= nowKST
+                return price.date >= last24hStartKST && price.date <= nowKST
             }
                         
             self.prices = filteredPrices.enumerated().map { idx, price in
@@ -135,7 +135,7 @@ extension ChartViewModel {
         let now = Date()
         let calendar = Calendar(identifier: .gregorian)
         let lastDate = data.last?.date ?? now
-        let xStart = calendar.startOfDay(for: now)
+        let xStart = now.addingTimeInterval(-60 * 60 * 24)
         let xEnd = lastDate.addingTimeInterval(60 * 5)
         return xStart...xEnd
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #210 

## 📝 작업 내용

- X축 도메인을 `오늘 자정 ~ 현재` → `현재 기준 24시간 전 ~ 현재`로 변경
  * 한 화면에 보이는 범위는 약 45분이며, 스크롤하면 24시간 전까지 이동 가능합니다.
- 차트 상단의 기간 선택 탭 제거
  * 차트 기간을 1분봉·최근 24시간으로 고정

### 스크린샷 (선택)
- 화면 진입 시 스크롤 위치 (현재 시각)
    <img height="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-14 at 01 18 15" src="https://github.com/user-attachments/assets/539bcb24-710f-4d81-bdf2-969651a78dfa" />

- 맨 왼쪽으로 스크롤 (현재로부터 24시간 전)
    <img height="400" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-14 at 01 18 23" src="https://github.com/user-attachments/assets/9f14d99a-4779-41cc-a2e3-9e692ddc2514" />

## 💬 리뷰 요구사항(선택)

