### PR TITLE
코인 상세 - 차트 테스트 코드 작성

### DIFF
--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -27,12 +27,22 @@ final class ChartViewModel: ObservableObject {
     /// 주기적 업데이트 태스크 (취소를 위해 저장)
     private var updateTask: Task<Void, Never>?
     
-    init(coin: Coin, priceService: CoinPriceProvider = UpbitPriceService()) {
+    /// 현재 시각을 제공하는 클로저
+    /// - 기본값: `Date()`
+    /// - 사용 목적: 테스트에서 현재 시각을 고정하여 시간 의존 로직(날짜 필터링 등)의 안정적인 검증을 가능하게 함
+    private let nowProvider: () -> Date
+    
+    init(
+        coin: Coin,
+        priceService: CoinPriceProvider = UpbitPriceService(),
+        nowProvider: @escaping () -> Date = { Date() }
+    ) {
         self.coinName = coin.koreanName
         self.coinSymbol = coin.id
         // id: "KRW-BTC" → currency: "KRW"
         self.currency = coin.id.split(separator: "-").first.map(String.init) ?? "KRW"
         self.priceService = priceService
+        self.nowProvider = nowProvider
         startUpdating()
     }
     


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #119 

## 📝 작업 내용

- **ViewModel**
  - `nowProvider` 주입으로 시간 의존성 분리(런타임 동작 변화 없음)
  - `loadPrices`에서 최근 24시간 [now-24h, now] 범위로 필터 적용
  - 차트 표시용 유틸 추가
    - `xAxisDomain(for:)`: 오늘 00:00 ~ 마지막 데이터 +5분
    - `scrollToTime(for:)`: 마지막 데이터 +5분
- **Tests**
  - `MockPriceProvider` 추가(네트워크 없이 결과/에러 주입)
  - `ChartViewModel_LoadPrices_Tests`: 최근 24h 필터(inclusive) & 순서 보존 검증
  - `ChartViewModel_Summary_Tests`: lastPrice / change / changeRate 계산 및 no-data 시 nil 검증
  - `ChartViewModel_Axis_Tests`: xAxisDomain / scrollToTime 검증

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

없습니다!
