### PR TITLE
ChartViewModel - 가격 불러오기 실패 로그/메모리 릭 수정

### DIFF
--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -184,6 +184,9 @@ struct ChartView: View {
         .onAppear {
             viewModel.checkBookmark()
         }
+        .onDisappear {
+            viewModel.stopUpdating()
+        }
         .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(Color.aiCoBackground)

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -93,9 +93,7 @@ struct ChartView: View {
                     CircleIconView(imageName: viewModel.isBookmarked ? "bookmark.fill" : "bookmark")
                 }
             }
-            
-            let chartRatio: CGFloat = 1.7
-            
+                        
             ZStack {
                 if data.isEmpty {
                     DefaultProgressView(

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -105,7 +105,7 @@ final class ChartViewModel: ObservableObject {
             }
         } catch is CancellationError {
             return
-        } catch let e as URLError where e.code == .cancelled {
+        } catch NetworkError.taskCancelled {
             return
         } catch {
             print("가격 불러오기 실패: \(error.localizedDescription)")

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -73,7 +73,7 @@ final class ChartViewModel: ObservableObject {
     
     /// 타이머 종료 및 메모리 정리
     deinit {
-        print("ChartViewModel deinit")
+        print(String(describing: Self.self) + " deinit")
         updateTask?.cancel()
     }
     

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -145,7 +145,6 @@ extension ChartViewModel {
     /// - Returns: 당일 자정부터 현재(마지막 데이터)까지의 시점이며, 여유 공간을 위한 현재 시점 +5분까지의 시간 범위 추가
     func xAxisDomain(for data: [CoinPrice]) -> ClosedRange<Date> {
         let now = Date()
-        let calendar = Calendar(identifier: .gregorian)
         let lastDate = data.last?.date ?? now
         let xStart = now.addingTimeInterval(-60 * 60 * 24)
         let xEnd = lastDate.addingTimeInterval(60 * 5)

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -51,17 +51,29 @@ final class ChartViewModel: ObservableObject {
     /// 주기적으로 가격 데이터를 불러오는 갱신 루프를 시작
     /// - Note: 최초 1회 실행 후 60초마다 반복 호출
     private func startUpdating() {
-        updateTask = Task {
-            await loadPrices()
-            while true {
-                try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
-                await loadPrices()
+        updateTask?.cancel() // 중복 시작 방지
+        
+        updateTask = Task { [weak self] in
+            await self?.loadPrices() // 최초 1회
+            
+            while !Task.isCancelled {
+                _ = try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
+                
+                if Task.isCancelled { break } // 취소 시 즉시 종료
+                
+                await self?.loadPrices()
             }
         }
     }
     
+    func stopUpdating() {
+        updateTask?.cancel()
+        updateTask = nil
+    }
+    
     /// 타이머 종료 및 메모리 정리
     deinit {
+        print("ChartViewModel deinit")
         updateTask?.cancel()
     }
     
@@ -91,6 +103,10 @@ final class ChartViewModel: ObservableObject {
                     index: idx
                 )
             }
+        } catch is CancellationError {
+            return
+        } catch let e as URLError where e.code == .cancelled {
+            return
         } catch {
             print("가격 불러오기 실패: \(error.localizedDescription)")
             self.prices = []


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #252 

## 📝 작업 내용

- `Task { [weak self] … }`로 약한 캡처 적용 → 순환 참조 제거
- `Task.sleep` 후 `Task.isCancelled` 체크로 갱신 루프 정상 종료
- `loadPrices`: `CancellationError`/`URLError.cancelled`도 처리 (이때는 실패 로그 미출력)
- `stopUpdating()` 추가
  - `ChartView`에 `.onDisappear { viewModel.stopUpdating() }` 연동
- `deinit:` `updateTask?.cancel() `호출 및 `deinit` 로그 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

차트 화면 이탈 후 `ChartViewModel` `deinit` 로그가 안정적으로 찍히는지(왕복 테스트) 확인해주시면 될 것 같습니다.
