### PR TITLE
코인 상세 – 캔들 차트 버그 수정 및 리팩토링

### DIFF
--- a/AIProject/AIProject/Data/API/Upbit/UpbitPriceService.swift
+++ b/AIProject/AIProject/Data/API/Upbit/UpbitPriceService.swift
@@ -30,6 +30,9 @@ final class UpbitPriceService: CoinPriceProvider {
         var toDate = interval.endDate
         
         while allCandles.count < interval.minutes {
+            // 상위 Task 취소 시 여기서 즉시 CancellationError를 던져 다음 요청/반복을 막기 위함
+            try Task.checkCancellation()
+            
             let count = min(candleLimit, interval.minutes - allCandles.count)
             let newCandles = try await api.fetchCandles(id: market, count: count, to: toDate)
             

--- a/AIProject/AIProject/Features/CoinDetail/FakePriceService.swift
+++ b/AIProject/AIProject/Features/CoinDetail/FakePriceService.swift
@@ -24,8 +24,7 @@ struct FakePriceService: CoinPriceProvider {
             case .success(let d, _), .empty(let d), .failure(let d): return UInt64(d * 1_000_000_000)
             }
         }()
-        try? await Task.sleep(nanoseconds: ns)
-
+        try await Task.sleep(nanoseconds: ns)
         try Task.checkCancellation()
         
         // 모드 분기

--- a/AIProject/AIProject/Features/CoinDetail/FakePriceService.swift
+++ b/AIProject/AIProject/Features/CoinDetail/FakePriceService.swift
@@ -1,0 +1,50 @@
+//
+//  FakePriceService.swift
+//  AIProject
+//
+//  Created by 강민지 on 8/20/25.
+//
+
+import Foundation
+
+/// PR용 테스트 (머지 전 삭제)
+#if DEBUG
+struct FakePriceService: CoinPriceProvider {
+    enum Mode {
+        case success(delaySec: Double, points: Int = 120) // 지연 후 성공
+        case empty(delaySec: Double)                      // 지연 후 빈 배열
+        case failure(delaySec: Double)                    // 지연 후 에러
+    }
+    let mode: Mode
+
+    func fetchPrices(market: String, interval: CoinInterval, to: Date?) async throws -> [CoinPrice] {
+        // 지연 주기
+        let ns: UInt64 = {
+            switch mode {
+            case .success(let d, _), .empty(let d), .failure(let d): return UInt64(d * 1_000_000_000)
+            }
+        }()
+        try? await Task.sleep(nanoseconds: ns)
+
+        // 모드 분기
+        switch mode {
+        case .success(_, let points):
+            let now = Date()
+            // 간단한 더미 OHLC 생성
+            let data: [CoinPrice] = (0..<points).map { i in
+                let t = now.addingTimeInterval(Double(-(points - i)) * 60)
+                let base = 10_000.0
+                return .init(
+                    date: t, open: base, high: base * 1.01, low: base * 0.99,
+                    close: base * (0.995 + Double(i)/Double(points)/100.0),
+                    trade: 1_234_567, index: i)
+            }
+            return data
+        case .empty:
+            return []
+        case .failure:
+            throw NetworkError.invalidResponse
+        }
+    }
+}
+#endif

--- a/AIProject/AIProject/Features/CoinDetail/FakePriceService.swift
+++ b/AIProject/AIProject/Features/CoinDetail/FakePriceService.swift
@@ -26,6 +26,8 @@ struct FakePriceService: CoinPriceProvider {
         }()
         try? await Task.sleep(nanoseconds: ns)
 
+        try Task.checkCancellation()
+        
         // 모드 분기
         switch mode {
         case .success(_, let points):

--- a/AIProject/AIProject/Features/CoinDetail/Previews/ChartView+Previews.swift
+++ b/AIProject/AIProject/Features/CoinDetail/Previews/ChartView+Previews.swift
@@ -1,0 +1,47 @@
+//
+//  ChartView+Previews.swift
+//  AIProject
+//
+//  Created by 강민지 on 8/21/25.
+//
+
+#if DEBUG
+import SwiftUI
+
+extension Coin {
+    static let previewBTC = Coin(id: "KRW-BTC", koreanName: "비트코인")
+}
+
+#Preview("성공(5초 지연)") {
+    ChartView(
+        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+        priceService: PreviewPriceService(mode: .success(delaySec: 5, points: 200))
+    )
+    .environmentObject(ThemeManager())
+}
+
+#Preview("취소 동작 확인") {
+    ChartView(
+        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+        priceService: PreviewPriceService(mode: .success(delaySec: 10))
+    )
+    .environmentObject(ThemeManager())
+    // 프리뷰 실행 후 2~3초 내 ‘작업 취소’ 버튼 눌러 상태 전환 확인
+}
+
+#Preview("실패 동작 확인") {
+    ChartView(
+        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+        priceService: PreviewPriceService(mode: .failure(delaySec: 2))
+    )
+    .environmentObject(ThemeManager())
+}
+
+#Preview("빈 데이터 동작 확인") {
+    ChartView(
+        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+        priceService: PreviewPriceService(mode: .empty(delaySec: 2))
+    )
+    .environmentObject(ThemeManager())
+}
+#endif

--- a/AIProject/AIProject/Features/CoinDetail/Previews/PreviewPriceService.swift
+++ b/AIProject/AIProject/Features/CoinDetail/Previews/PreviewPriceService.swift
@@ -1,5 +1,5 @@
 //
-//  FakePriceService.swift
+//  PreviewPriceService.swift
 //  AIProject
 //
 //  Created by 강민지 on 8/20/25.
@@ -7,9 +7,8 @@
 
 import Foundation
 
-/// PR용 테스트 (머지 전 삭제)
 #if DEBUG
-struct FakePriceService: CoinPriceProvider {
+struct PreviewPriceService: CoinPriceProvider {
     enum Mode {
         case success(delaySec: Double, points: Int = 120) // 지연 후 성공
         case empty(delaySec: Double)                      // 지연 후 빈 배열

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -90,7 +90,7 @@ struct ChartView: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(.default, lineWidth: 0.5)
+                .stroke(.defaultGradient, lineWidth: 0.5)
         )
     }
     
@@ -180,24 +180,6 @@ struct ChartView: View {
                 )
             }
         }
-    }
-    
-    var body: some View {
-        VStack(alignment: .leading) {
-            headerView
-            chartArea
-        }
-        .padding(20)
-        .onAppear { viewModel.checkBookmark() }
-        .onDisappear { viewModel.stopUpdating() }
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(Color.aiCoBackground)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(.defaultGradient, lineWidth: 0.5)
-        )
     }
 }
 

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -154,14 +154,19 @@ struct ChartView: View {
                             }
                         }
                     }
-                    /// Y축 눈금 (20만 원 단위) + 값 포맷을 M(억) 단위로 축약
                     .chartYAxis {
-                        AxisMarks(values: .stride(by: 200_000)) { value in // 20만원 단위 눈금 표시
+                        AxisMarks { value in
                             AxisGridLine()
                             AxisTick()
-                            if let price = value.as(Double.self) {
+                            if let v = value.as(Double.self) {
                                 AxisValueLabel {
-                                    Text(String(format: "%.1fM", price / 1_000_000))
+                                    if yRange.upperBound >= 1_000_000 {
+                                        Text(String(format: "%.1fM", v / 1_000_000)) // 백만 단위
+                                    } else if yRange.upperBound >= 1_000 {
+                                        Text(String(format: "%.1fK", v / 1_000)) // 천 단위
+                                    } else {
+                                        Text(String(format: "%.0f", v)) // 원 단위 그대로
+                                    }
                                 }
                             }
                         }

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -50,9 +50,10 @@ struct ChartView: View {
                     // 요약 데이터 유무
                     let hasSummary = (summary != nil)
                     
-                    let lastPrice = summary?.lastPrice ?? 0
-                    let changeValue = summary?.change ?? 0
-                    let changeRate  = summary?.changeRate ?? 0
+                    let lastPrice   = viewModel.headerLastPrice != 0 ? viewModel.headerLastPrice : (summary?.lastPrice ?? 0)
+                    let changeValue = viewModel.headerLastPrice != 0 ? viewModel.headerChangePrice  : (summary?.change ?? 0)
+                    let changeRate  = viewModel.headerLastPrice != 0 ? viewModel.headerChangeRate : (summary?.changeRate ?? 0)
+                    let trade = viewModel.headerAccTradePrice
                     
                     let isRising = changeValue > 0
                     let isFalling = changeValue < 0
@@ -74,7 +75,6 @@ struct ChartView: View {
                         .lineLimit(1)
                         .opacity(hasSummary ? 1 : 0)
                     
-                    let trade = viewModel.prices.last?.trade ?? 0
                     Text("거래대금 \(trade.formatMillion)")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(.aiCoLabelSecondary)

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -81,7 +81,6 @@ struct ChartView: View {
             }
             chartArea
         }
-        .animation(.easeInOut(duration: 0.2), value: shouldShowHeader)
         .padding(20)
         .onAppear { viewModel.checkBookmark() }
         .onDisappear { viewModel.stopUpdating() }

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -57,7 +57,7 @@ struct ChartView: View {
                         .lineLimit(1)
                     
                     // 요약 데이터 유무
-                    let hasSummary = (summary != nil)
+                    let hasHeader = (viewModel.headerLastPrice != 0) || (summary != nil)
                     
                     let lastPrice   = viewModel.headerLastPrice != 0 ? viewModel.headerLastPrice : (summary?.lastPrice ?? 0)
                     let changeValue = viewModel.headerLastPrice != 0 ? viewModel.headerChangePrice  : (summary?.change ?? 0)
@@ -76,19 +76,19 @@ struct ChartView: View {
                         .font(.system(size: 20, weight: .bold))
                         .foregroundStyle(.aiCoLabel)
                         .lineLimit(1)
-                        .opacity(hasSummary ? 1 : 0)
+                        .opacity(hasHeader ? 1 : 0)
                     
                     Text("\(sign)\(abs(changeValue).formatKRW) (\(arrow)\(abs(changeRate).formatRate))")
                         .font(.system(size: 16, weight: .medium))
                         .foregroundStyle(color)
                         .lineLimit(1)
-                        .opacity(hasSummary ? 1 : 0)
+                        .opacity(hasHeader ? 1 : 0)
                     
                     Text("거래대금 \(trade.formatMillion)")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(.aiCoLabelSecondary)
                         .lineLimit(1)
-                        .opacity(hasSummary ? 1 : 0)
+                        .opacity(hasHeader ? 1 : 0)
                 }
                 
                 Spacer()

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -151,76 +151,15 @@ struct ChartView: View {
                         let scrollTo = viewModel.scrollToTime(for: data)
                         
                         /// 캔들 차트: 가격 시계열을 고가/저가 선(RuleMark) + 시가/종가 직사각형(RectangleMark)으로 표현
-                        Chart(data) { point in
-                            /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
-                            RuleMark(
-                                x: .value("Date", point.date),
-                                yStart: .value("Low", point.low),
-                                yEnd: .value("High", point.high)
-                            )
-                            .foregroundStyle(
-                                point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
-                            )
-                            
-                            /// 시가/종가 직사각형 (실체 바)
-                            RectangleMark(
-                                x: .value("Date", point.date),
-                                yStart: .value("Open", point.open),
-                                yEnd: .value("Close", point.close),
-                                width: 6
-                            )
-                            .foregroundStyle(
-                                point.close >= point.open ? themeManager.selectedTheme.positiveColor : themeManager.selectedTheme.negativeColor
-                            )
-                        }
-                        /// X축 도메인 설정 및 스크롤 위치 초기화
-                        .chartXScale(domain: xDomain)
-                        .chartScrollPosition(initialX: scrollTo)
-                        .chartScrollableAxes(.horizontal)
-                        /// Y축 도메인 설정 (동적 범위)
-                        .chartYScale(domain: yRange)
-                        /// 한 화면에서 보이는 X축 범위 (2880초 = 48분)
-                        .chartXVisibleDomain(length: 2880)
-                        /// X축 눈금 (15분 간격) + 1시간마다 세로선 표시
-                        .chartXAxis {
-                            AxisMarks(values: .stride(by: .minute, count: 15)) { value in
-                                AxisTick()
-                                AxisValueLabel {
-                                    if let date = value.as(Date.self) {
-                                        Text(viewModel.timeFormatter.string(from: date))
-                                    }
-                                }
-                                
-                                /// 세로선은 1시간 단위(분 == 0)일 때만 표시
-                                if let date = value.as(Date.self),
-                                   Calendar.current.component(.minute, from: date) == 0 {
-                                    AxisGridLine()
-                                }
-                            }
-                        }
-                        .chartYAxis {
-                            AxisMarks { value in
-                                AxisGridLine()
-                                AxisTick()
-                                if let v = value.as(Double.self) {
-                                    AxisValueLabel {
-                                        if yRange.upperBound >= 1_000_000 {
-                                            Text(String(format: "%.1fM", v / 1_000_000)) // 백만 단위
-                                        } else if yRange.upperBound >= 1_000 {
-                                            Text(String(format: "%.1fK", v / 1_000)) // 천 단위
-                                        } else {
-                                            Text(String(format: "%.0f", v)) // 원 단위 그대로
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        /// 차트 오른쪽 영역에 여백 추가
-                        .chartPlotStyle { plotArea in
-                            plotArea
-                                .padding(.trailing, 10)
-                                .padding(.bottom, 8)
-                        }
+                        CandleChartView(
+                            data: data,
+                            xDomain: xDomain,
+                            yRange: yRange,
+                            scrollTo: scrollTo,
+                            timeFormatter: viewModel.timeFormatter,
+                            positiveColor: themeManager.selectedTheme.positiveColor,
+                            negativeColor: themeManager.selectedTheme.negativeColor
+                        )
                     }
                 }
             }
@@ -284,3 +223,79 @@ struct ChartView: View {
 //    )
 //    .environmentObject(ThemeManager())
 //}
+
+struct CandleChartView: View {
+    let data: [CoinPrice]
+    let xDomain: ClosedRange<Date>
+    let yRange: ClosedRange<Double>
+    let scrollTo: Date
+    let timeFormatter: DateFormatter
+    let positiveColor: Color
+    let negativeColor: Color
+    private let barWidth: CGFloat = 6
+    
+    var body: some View {
+        Chart(data) { point in
+            /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
+            RuleMark(
+                x: .value("Date", point.date),
+                yStart: .value("Low", point.low),
+                yEnd: .value("High", point.high)
+            )
+            .foregroundStyle( point.close >= point.open ? positiveColor : negativeColor )
+            
+            /// 시가/종가 직사각형 (실체 바)
+            RectangleMark(
+                x: .value("Date", point.date),
+                yStart: .value("Open", point.open),
+                yEnd: .value("Close", point.close),
+                width: 6
+            )
+            .foregroundStyle( point.close >= point.open ? positiveColor : negativeColor )
+        }
+        /// X축 도메인 설정 및 스크롤 위치 초기화
+        .chartXScale(domain: xDomain)
+        .chartScrollPosition(initialX: scrollTo)
+        .chartScrollableAxes(.horizontal)
+        /// Y축 도메인 설정 (동적 범위)
+        .chartYScale(domain: yRange)
+        /// 한 화면에서 보이는 X축 범위 (2880초 = 48분)
+        .chartXVisibleDomain(length: 2880)
+        /// X축 눈금 (15분 간격) + 1시간마다 세로선 표시
+        .chartXAxis {
+            AxisMarks(values: .stride(by: .minute, count: 15)) { value in
+                AxisTick()
+                AxisValueLabel {
+                    if let date = value.as(Date.self) {
+                        Text(timeFormatter.string(from: date))
+                    }
+                }
+                
+                /// 세로선은 1시간 단위(분 == 0)일 때만 표시
+                if let date = value.as(Date.self),
+                   Calendar.current.component(.minute, from: date) == 0 {
+                    AxisGridLine()
+                }
+            }
+        }
+        .chartYAxis {
+            AxisMarks { value in
+                AxisGridLine()
+                AxisTick()
+                if let v = value.as(Double.self) {
+                    AxisValueLabel {
+                        if yRange.upperBound >= 1_000_000 {
+                            Text(String(format: "%.1fM", v / 1_000_000)) // 백만 단위
+                        } else if yRange.upperBound >= 1_000 {
+                            Text(String(format: "%.1fK", v / 1_000)) // 천 단위
+                        } else {
+                            Text(String(format: "%.0f", v)) // 원 단위 그대로
+                        }
+                    }
+                }
+            }
+        }
+        /// 차트 오른쪽 영역에 여백 추가
+        .chartPlotStyle { $0.padding(.trailing, 10).padding(.bottom, 8) }
+    }
+}

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -239,22 +239,22 @@ struct ChartView: View {
 //}
 
 /// PR용 테스트 (머지 전 삭제)
-#Preview("성공(5초 지연)") {
-    ChartView(
-        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
-        priceService: FakePriceService(mode: .success(delaySec: 5, points: 200))
-    )
-    .environmentObject(ThemeManager())
-}
-
-//#Preview("취소 동작 확인") {
+//#Preview("성공(5초 지연)") {
 //    ChartView(
 //        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
-//        priceService: FakePriceService(mode: .success(delaySec: 10))
+//        priceService: FakePriceService(mode: .success(delaySec: 5, points: 200))
 //    )
 //    .environmentObject(ThemeManager())
-//    // 프리뷰 실행 후 2~3초 내 ‘작업 취소’ 버튼 눌러 상태 전환 확인
 //}
+
+#Preview("취소 동작 확인") {
+    ChartView(
+        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+        priceService: FakePriceService(mode: .success(delaySec: 10))
+    )
+    .environmentObject(ThemeManager())
+    // 프리뷰 실행 후 2~3초 내 ‘작업 취소’ 버튼 눌러 상태 전환 확인
+}
 
 //#Preview("실패 동작 확인") {
 //    ChartView(

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -23,10 +23,19 @@ struct ChartView: View {
     /// 헤더의 가격 요약 정보(마지막가 / 변화 / 등락률)
     private var summary: PriceSummary? { viewModel.summary }
 
-    init(coin: Coin) {
-        _viewModel = StateObject(wrappedValue:  ChartViewModel(coin: coin))
-    }
+//    init(coin: Coin) {
+//        _viewModel = StateObject(wrappedValue:  ChartViewModel(coin: coin))
+//    }
     
+    /// PR용 테스트 (머지 전 삭제)
+    init(coin: Coin, priceService: CoinPriceProvider? = nil) {
+        if let ps = priceService {
+            _viewModel = StateObject(wrappedValue: ChartViewModel(coin: coin, priceService: ps))
+        } else {
+            _viewModel = StateObject(wrappedValue: ChartViewModel(coin: coin))
+        }
+    }
+
     private static let headerDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy.MM.dd HH:mm"
@@ -220,7 +229,41 @@ struct ChartView: View {
     }
 }
 
-#Preview {
-    ChartView(coin: Coin(id: "KRW-BTC", koreanName: "비트코인"))
-        .environmentObject(ThemeManager())
+//#Preview {
+//    ChartView(coin: Coin(id: "KRW-BTC", koreanName: "비트코인"))
+//        .environmentObject(ThemeManager())
+//}
+
+/// PR용 테스트 (머지 전 삭제)
+#Preview("성공(5초 지연)") {
+    ChartView(
+        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+        priceService: FakePriceService(mode: .success(delaySec: 5, points: 200))
+    )
+    .environmentObject(ThemeManager())
 }
+
+//#Preview("취소 동작 확인") {
+//    ChartView(
+//        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+//        priceService: FakePriceService(mode: .success(delaySec: 10))
+//    )
+//    .environmentObject(ThemeManager())
+//    // 프리뷰 실행 후 2~3초 내 ‘작업 취소’ 버튼 눌러 상태 전환 확인
+//}
+
+//#Preview("실패 동작 확인") {
+//    ChartView(
+//        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+//        priceService: FakePriceService(mode: .failure(delaySec: 2))
+//    )
+//    .environmentObject(ThemeManager())
+//}
+
+//#Preview("빈 데이터 동작 확인") {
+//    ChartView(
+//        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+//        priceService: FakePriceService(mode: .empty(delaySec: 2))
+//    )
+//    .environmentObject(ThemeManager())
+//}

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -39,10 +39,22 @@ struct ChartView: View {
     private static let headerDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy.MM.dd HH:mm"
+//        f.locale = Locale(identifier: "ko_KR")
         return f
     }()
+    
+    /// 뷰모델이 제공하는 기준 시각 사용 (없으면 빈 문자열)
     private var lastUpdatedText: String {
-        Self.headerDateFormatter.string(from: Date()) + " 기준"
+        guard let time = viewModel.lastUpdated else { return "" }
+        return Self.headerDateFormatter.string(from: time) + " 기준"
+    }
+    
+    /// 헤더는 성공 상태이면서 기준 시각이 있을 때만 보이도록 (깜빡임/오표시 방지)
+    private var headerOpacity: Double {
+        if case .success = viewModel.status, viewModel.lastUpdated != nil {
+            return 1
+        }
+        return 0
     }
     
     var body: some View {
@@ -55,6 +67,7 @@ struct ChartView: View {
                         .font(.system(size: 10, weight: .regular))
                         .foregroundStyle(.aiCoLabel)
                         .lineLimit(1)
+                        .opacity(headerOpacity)
                     
                     // 헤더 표시 조건:
                     // - Ticker 기반 값이 도착했으면(summary 유무와 무관하게) 헤더를 보여줌
@@ -239,22 +252,22 @@ struct ChartView: View {
 //}
 
 /// PR용 테스트 (머지 전 삭제)
-//#Preview("성공(5초 지연)") {
-//    ChartView(
-//        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
-//        priceService: FakePriceService(mode: .success(delaySec: 5, points: 200))
-//    )
-//    .environmentObject(ThemeManager())
-//}
-
-#Preview("취소 동작 확인") {
+#Preview("성공(5초 지연)") {
     ChartView(
         coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
-        priceService: FakePriceService(mode: .success(delaySec: 10))
+        priceService: FakePriceService(mode: .success(delaySec: 5, points: 200))
     )
     .environmentObject(ThemeManager())
-    // 프리뷰 실행 후 2~3초 내 ‘작업 취소’ 버튼 눌러 상태 전환 확인
 }
+
+//#Preview("취소 동작 확인") {
+//    ChartView(
+//        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
+//        priceService: FakePriceService(mode: .success(delaySec: 10))
+//    )
+//    .environmentObject(ThemeManager())
+//    // 프리뷰 실행 후 2~3초 내 ‘작업 취소’ 버튼 눌러 상태 전환 확인
+//}
 
 //#Preview("실패 동작 확인") {
 //    ChartView(

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -23,18 +23,28 @@ struct ChartView: View {
     /// 헤더의 가격 요약 정보(마지막가 / 변화 / 등락률)
     private var summary: PriceSummary? { viewModel.summary }
 
-//    init(coin: Coin) {
-//        _viewModel = StateObject(wrappedValue:  ChartViewModel(coin: coin))
-//    }
-    
-    /// PR용 테스트 (머지 전 삭제)
-    init(coin: Coin, priceService: CoinPriceProvider? = nil) {
-        if let ps = priceService {
-            _viewModel = StateObject(wrappedValue: ChartViewModel(coin: coin, priceService: ps))
-        } else {
-            _viewModel = StateObject(wrappedValue: ChartViewModel(coin: coin))
-        }
+    /// 프로덕션 기본 경로
+    init(coin: Coin) {
+        _viewModel = StateObject(wrappedValue:  ChartViewModel(coin: coin))
     }
+    
+    #if DEBUG
+    /// 프리뷰/디버그 전용 주입 경로
+    init(
+        coin: Coin,
+        priceService: any CoinPriceProvider,
+        tickerAPI: UpBitAPIService = UpBitAPIService()
+    ) {
+        _viewModel = StateObject(
+            wrappedValue: ChartViewModel(
+                coin: coin,
+                priceService: priceService,
+                tickerAPI: tickerAPI
+            )
+        )
+    }
+    #endif
+
 
     private static let headerDateFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -177,39 +187,7 @@ struct ChartView: View {
 //        .environmentObject(ThemeManager())
 //}
 
-/// PR용 테스트 (머지 전 삭제)
-#Preview("성공(5초 지연)") {
-    ChartView(
-        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
-        priceService: FakePriceService(mode: .success(delaySec: 5, points: 200))
-    )
-    .environmentObject(ThemeManager())
-}
 
-//#Preview("취소 동작 확인") {
-//    ChartView(
-//        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
-//        priceService: FakePriceService(mode: .success(delaySec: 10))
-//    )
-//    .environmentObject(ThemeManager())
-//    // 프리뷰 실행 후 2~3초 내 ‘작업 취소’ 버튼 눌러 상태 전환 확인
-//}
-
-//#Preview("실패 동작 확인") {
-//    ChartView(
-//        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
-//        priceService: FakePriceService(mode: .failure(delaySec: 2))
-//    )
-//    .environmentObject(ThemeManager())
-//}
-
-//#Preview("빈 데이터 동작 확인") {
-//    ChartView(
-//        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
-//        priceService: FakePriceService(mode: .empty(delaySec: 2))
-//    )
-//    .environmentObject(ThemeManager())
-//}
 
 struct CandleChartView: View {
     let data: [CoinPrice]

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -56,9 +56,13 @@ struct ChartView: View {
                         .foregroundStyle(.aiCoLabel)
                         .lineLimit(1)
                     
-                    // 요약 데이터 유무
+                    // 헤더 표시 조건:
+                    // - Ticker 기반 값이 도착했으면(summary 유무와 무관하게) 헤더를 보여줌
+                    // - Ticker도 실패하고 summary도 없으면 숨김(초기 로딩/취소/실패 시 깜빡임 방지)
                     let hasHeader = (viewModel.headerLastPrice != 0) || (summary != nil)
                     
+                    /// 헤더 표기는 목록 화면과 동일 정의를 위해 Ticker 기반 값을 우선 사용
+                    /// (Ticker 실패 시 summary)
                     let lastPrice   = viewModel.headerLastPrice != 0 ? viewModel.headerLastPrice : (summary?.lastPrice ?? 0)
                     let changeValue = viewModel.headerLastPrice != 0 ? viewModel.headerChangePrice  : (summary?.change ?? 0)
                     let changeRate  = viewModel.headerLastPrice != 0 ? viewModel.headerChangeRate : (summary?.changeRate ?? 0)

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -49,7 +49,7 @@ struct ChartView: View {
     private static let headerDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy.MM.dd HH:mm"
-//        f.locale = Locale(identifier: "ko_KR")
+        f.locale = Locale(identifier: "ko_KR")
         return f
     }()
     
@@ -189,6 +189,7 @@ struct ChartView: View {
 
 
 
+/// 캔들 차트: 가격 시계열을 고가/저가 선(RuleMark) + 시가/종가 직사각형(RectangleMark)으로 표현
 struct CandleChartView: View {
     let data: [CoinPrice]
     let xDomain: ClosedRange<Date>

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -260,12 +260,10 @@ extension ChartViewModel {
 }
 
 extension ChartViewModel {
-    /// 헤더를 보여줄 수 있는지
-    /// 헤더 표시 조건:
-    /// - Ticker 기반 값이 도착했으면(summary 유무와 무관하게) 헤더를 보여줌
-    /// - Ticker도 실패하고 summary도 없으면 숨김(초기 로딩/취소/실패 시 깜빡임 방지)
+    /// 헤더 노출: 최근 캔들 있음(`lastUpdated != nil`) && (티커값(`headerLastPrice != 0`) 또는 `summary` 존재)
+    /// 헤더 숨김: 캔들 없음(로딩/실패/빈 데이터) → 레이아웃 밀림 방지
     var hasHeader: Bool {
-        headerLastPrice != 0 || summary != nil
+        (lastUpdated != nil) && (headerLastPrice != 0 || summary != nil)
     }
     
     /// 표시에 사용할 값들

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -161,10 +161,12 @@ final class ChartViewModel: ObservableObject {
             status = .cancel(.taskCancelled)
             return
         } catch {
-            let err = (error as? NetworkError) ?? .networkError(error)
-#if DEBUG
+            let err = (error as? NetworkError)
+                ?? (error as? URLError).map(NetworkError.networkError)
+                ?? .networkError(URLError(.unknown))
+            #if DEBUG
             print("가격 불러오기 실패: \(err.log())")
-#endif
+            #endif
             status = .failure(err)
         }
     }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -245,3 +245,26 @@ extension ChartViewModel {
         return formatter
     }
 }
+
+extension ChartViewModel {
+    /// 헤더를 보여줄 수 있는지
+    /// 헤더 표시 조건:
+    /// - Ticker 기반 값이 도착했으면(summary 유무와 무관하게) 헤더를 보여줌
+    /// - Ticker도 실패하고 summary도 없으면 숨김(초기 로딩/취소/실패 시 깜빡임 방지)
+    var hasHeader: Bool {
+        headerLastPrice != 0 || summary != nil
+    }
+    
+    /// 표시에 사용할 값들
+    /// 헤더 표기는 목록 화면과 동일 정의를 위해 Ticker 기반 값을 우선 사용
+    /// (Ticker 우선, 실패 시 summary fallback)
+    var displayLastPrice: Double {
+        headerLastPrice != 0 ? headerLastPrice : (summary?.lastPrice ?? 0)
+    }
+    var displayChangeValue: Double {
+        headerLastPrice != 0 ? headerChangePrice : (summary?.change ?? 0)
+    }
+    var displayChangeRate: Double {
+        headerLastPrice != 0 ? headerChangeRate : (summary?.changeRate ?? 0)
+    }
+}

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -118,6 +118,7 @@ final class ChartViewModel: ObservableObject {
             let (fetchedPrices, tickers) = try await (pricesTask, tickerTask)
             let ticker = tickers.first
                         
+            try Task.checkCancellation()  
             let now = Date()
             let startTime = now.addingTimeInterval(-24 * 60 * 60)
 
@@ -153,6 +154,10 @@ final class ChartViewModel: ObservableObject {
             }
             
             /// 성공 상태로 마무리 (데이터 유무는 뷰에서 처리)
+            guard !Task.isCancelled else {
+                status = .cancel(.taskCancelled)
+                return
+            }
             status = .success
         } catch is CancellationError {
             status = .cancel(.taskCancelled)

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -40,14 +40,27 @@ final class ChartViewModel: ObservableObject {
     /// 가격 데이터를 가져오는 서비스
     private let priceService: CoinPriceProvider
     
+    /// 헤더 지표용 ticker 조회 서비스
+    private let tickerAPI: UpBitAPIService
+    
     /// 주기적 업데이트 태스크 (취소를 위해 저장)
     private var updateTask: Task<Void, Never>?
     
-    init(coin: Coin, priceService: CoinPriceProvider = UpbitPriceService()) {
+    /// 차트 화면 상태를 초기화
+    /// - Parameters:
+    ///   - coin: 화면에 바인딩할 코인 정보
+    ///   - priceService: 분봉(캔들) 조회 서비스
+    ///   - tickerAPI: 헤더용 티커 조회 API
+    init(
+        coin: Coin,
+        priceService: CoinPriceProvider = UpbitPriceService(),
+        tickerAPI: UpBitAPIService = UpBitAPIService()
+    ) {
         self.coinName = coin.koreanName
         self.coinSymbol = coin.id
         self.currency = coin.id.split(separator: "-").first.map(String.init) ?? "KRW"
         self.priceService = priceService
+        self.tickerAPI = tickerAPI
         startUpdating()
     }
     
@@ -116,7 +129,7 @@ final class ChartViewModel: ObservableObject {
             /// - 분봉(차트용): 캔들 렌더링에 사용
             /// - Ticker(헤더용): 전일 대비/누적 거래대금 등 헤더 지표(목록 화면과 동일 정의)에 사용
             async let pricesTask: [CoinPrice] = priceService.fetchPrices(market: marketCode, interval: interval)
-            async let tickerTask = UpBitAPIService().fetchTicker(by: currency)
+            async let tickerTask: [TickerValue] = tickerAPI.fetchTicker(by: currency)
 
             let (fetchedPrices, tickers) = try await (pricesTask, tickerTask)
             try Task.checkCancellation()  


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #239 

## 📝 작업 내용

- **차트 화면의 헤더 값 통일(코인 목록과 동일 기준)**
 현재가 / 등락가 / 등락률 / 누적 거래대금 계산을 `TickerValue` 기준으로 재맵핑
`Ticker` 호출을 목록과 동일한 `/v1/ticker/all?quote_currencies=KRW`로 변경
(`Ticker` 실패 시 기존 차트 데이터`summary` 로 폴백)

- **특정 코인은 차트 Y축이 안보이는 문제 해결**
Y축 항상 노출 + `K/M/원` 단위 자동 포맷(`0.0M`만 보이는 이슈 제거)

- **에러/취소 처리**
`ResponseStatus(.loading/.success/.failure/.cancel)` 도입 
로딩 중 취소 시 즉시 `.cancel `유지(깜빡임 제거)
에러 시 기존 `prices` 보존 (디버그 로그만 출력), 취소/재시도 동작 추가

- **PR 테스트용 코드 추가 (머지 전 제거 예정)**
`FakePriceService` + `ChartView` 프리뷰 시나리오(로딩 / 취소 / 실패 / 빈 데이터) 추가
  - 머지 전 제거 예정 ➡️ 프리뷰/테스트 경로 상시 유지 (별도 파일, DEBUG 전용) `ChartView+Previews.swift`, `PreviewPriceService`(구 `FakePriceService`)

- **헤더** 
  - 캔들 없을 때도 티커가 오면 헤더 보임 ➡️ 캔들 없을 시(최근 24시간 데이터 미존재 시) 헤더 미노출 & 캔들이 없으면 티커가 와도 헤더 숨김 
  - `ProgressView`만 보일 때 헤더 공간으로 인해 아래로 쳐짐 ➡️ 로딩/빈 데이터 시 상단 여백 제거하여 `ProgressView`만 보일 때 헤더 공간이 레이아웃을 밀지 않음

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- **에러/취소 처리 확인**
`ChartView.swift` 하단의 프리뷰 케이스를 한 번에 하나씩 주석 해제하고 실행해 주시면 됩니다!
  ```Swift 
  /// PR용 테스트 (머지 전 삭제)
  #Preview("성공(5초 지연)") {
      ChartView(
          coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
          priceService: FakePriceService(mode: .success(delaySec: 5, points: 200))
      )
      .environmentObject(ThemeManager())
  }
  
  //#Preview("취소 동작 확인") {
  //    ChartView(
  //        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
  //        priceService: FakePriceService(mode: .success(delaySec: 10))
  //    )
  //    .environmentObject(ThemeManager())
  //    // 프리뷰 실행 후 2~3초 내 ‘작업 취소’ 버튼 눌러 상태 전환 확인
  //}
  
  //#Preview("실패 동작 확인") {
  //    ChartView(
  //        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
  //        priceService: FakePriceService(mode: .failure(delaySec: 2))
  //    )
  //    .environmentObject(ThemeManager())
  //}
  
  //#Preview("빈 데이터 동작 확인") {
  //    ChartView(
  //        coin: Coin(id: "KRW-BTC", koreanName: "비트코인"),
  //        priceService: FakePriceService(mode: .empty(delaySec: 2))
  //    )
  //    .environmentObject(ThemeManager())
  //}
  ```
  - **성공(지연):** 스피너 → 성공 전환, 차트/축 포맷 정상
  - **취소:** 로딩 중 `작업 취소` 클릭 → 즉시 `.cancel` 전환
  - **실패:** `.failure` 전환 + `다시 시도` 동작 확인
  - **빈 데이터:** 상태는 `.success`지만 `data.isEmpty` 분기로 “최근 24시간 체결 데이터가 없어요” 안내

- **코인 목록과 코인 상세 데이터가 일치하는지 확인**
  - 마켓 화면 → 코인 상세 화면 진입 시 헤더 값(현재가/등락가/등락률/누적 거래대금)이 목록과 일치하는지
  - Y축이 항상 보이고 단위가 상황에 맞게 K/M/원으로 표기되는지
