### PR TITLE
코인별 AI 리포트 아이패드 대응

### DIFF
--- a/AIProject/AIProject/Core/Util/String+Util.swift
+++ b/AIProject/AIProject/Core/Util/String+Util.swift
@@ -1,5 +1,5 @@
 //
-//  String+ExtractJSON.swift
+//  String+Util.swift
 //  AIProject
 //
 //  Created by 장지현 on 8/4/25.
@@ -54,7 +54,7 @@ extension String {
     }
     
     /// AI 생성 답변 컨텐츠 안내 문구를 전역에서 재사용할 수 있도록 String 타입에 정적 프로퍼티로 추가하는 확장
-    static var aiGeneratedContentNotice = "ⓘ 해당 컨텐츠는 생성형 AI가 생성한 응답으로 내용에 오류가 있을 수 있습니다. 투자 결정 시 유의하세요."
+    static var aiGeneratedContentNotice = "ⓘ 해당 컨텐츠는 생성형 AI가 생성한 응답으로 내용에 오류가 있을 수 있습니다. 투자 결정 시 유의하세요.".byCharWrapping
 
     /// 문자열 내의 숫자와 기호를 찾아 지정한 색상과 두께로 강조한 Text로 반환하는 확장
     ///  - Regex:

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportNewsSectionView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportNewsSectionView.swift
@@ -35,7 +35,7 @@ struct ReportNewsSectionView: View {
             ForEach(displayedArticles, id: \.id) { article in
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        Text(article.title)
+                        Text(article.title.byCharWrapping)
                             .font(.system(size: 15, weight: .bold))
                             .foregroundStyle(.aiCoLabel)
                             .lineLimit(1)

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -26,6 +26,8 @@ struct ReportView: View {
                 Text(String.aiGeneratedContentNotice)
                     .font(.system(size: 11))
                     .foregroundStyle(.aiCoNeutral)
+                    .lineSpacing(5)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 
                 ReportSectionView(
                     icon: "text.page.badge.magnifyingglass",

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -24,49 +24,48 @@ struct ReportView: View {
     
     var body: some View {
         let content =
-            VStack(spacing: 16) {
-                Text(String.aiGeneratedContentNotice)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.aiCoNeutral)
-                    .lineSpacing(5)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                
-                ReportSectionView(
-                    icon: "text.page.badge.magnifyingglass",
-                    title: "한눈에 보는 \(viewModel.koreanName)",
-                    state: viewModel.overview,
-                    onCancel: { viewModel.cancelOverview() },
-                    onRetry: { viewModel.retryOverview() }
-                ) { value in
-                    Text(value)
-                }
-                
-                ReportSectionView(
-                    icon: "calendar",
-                    title: "주간 동향",
-                    state: viewModel.weekly,
-                    onCancel: { viewModel.cancelWeekly() },
-                    onRetry: { viewModel.retryWeekly() }
-                ) { value in
-                    Text(AttributedString(value.byCharWrapping))
-                }
-                
-                ReportSectionView(
-                    icon: "shareplay",
-                    title: "오늘 시장의 분위기",
-                    state: viewModel.today,
-                    onCancel: { viewModel.cancelToday() },
-                    onRetry: { viewModel.retryToday() }
-                ) { value in
-                    Text(AttributedString(value.byCharWrapping))
-                }
-                
-                if case .success = viewModel.today,
-                   !viewModel.news.allSatisfy({ $0.title.isEmpty && $0.summary.isEmpty }) {
-                    ReportNewsSectionView(articles: viewModel.news)
-                        .padding(.bottom, 30)
-                }
+        VStack(alignment: .leading, spacing: 16) {
+            Text(String.aiGeneratedContentNotice)
+                .font(.system(size: 11))
+                .foregroundStyle(.aiCoNeutral)
+                .lineSpacing(5)
+            
+            ReportSectionView(
+                icon: "text.page.badge.magnifyingglass",
+                title: "한눈에 보는 \(viewModel.koreanName)",
+                state: viewModel.overview,
+                onCancel: { viewModel.cancelOverview() },
+                onRetry: { viewModel.retryOverview() }
+            ) { value in
+                Text(value)
             }
+            
+            ReportSectionView(
+                icon: "calendar",
+                title: "주간 동향",
+                state: viewModel.weekly,
+                onCancel: { viewModel.cancelWeekly() },
+                onRetry: { viewModel.retryWeekly() }
+            ) { value in
+                Text(AttributedString(value.byCharWrapping))
+            }
+            
+            ReportSectionView(
+                icon: "shareplay",
+                title: "오늘 시장의 분위기",
+                state: viewModel.today,
+                onCancel: { viewModel.cancelToday() },
+                onRetry: { viewModel.retryToday() }
+            ) { value in
+                Text(AttributedString(value.byCharWrapping))
+            }
+            
+            if case .success = viewModel.today,
+               !viewModel.news.allSatisfy({ $0.title.isEmpty && $0.summary.isEmpty }) {
+                ReportNewsSectionView(articles: viewModel.news)
+                    .padding(.bottom, 30)
+            }
+        }
         
         if hSizeClass == .regular && vSizeClass == .regular {
             VStack(alignment: .leading, spacing: 16) {

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -47,7 +47,9 @@ struct ReportView: View {
                 onCancel: { viewModel.cancelWeekly() },
                 onRetry: { viewModel.retryWeekly() }
             ) { value in
-                Text(AttributedString(value.byCharWrapping))
+                value
+                    .byCharWrapping
+                    .highlightTextForNumbersOperator()
             }
             
             ReportSectionView(
@@ -57,7 +59,9 @@ struct ReportView: View {
                 onCancel: { viewModel.cancelToday() },
                 onRetry: { viewModel.retryToday() }
             ) { value in
-                Text(AttributedString(value.byCharWrapping))
+                value
+                    .byCharWrapping
+                    .highlightTextForNumbersOperator()
             }
             
             if case .success = viewModel.today,

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -14,6 +14,8 @@ import SwiftUI
 /// - Parameters:
 ///   - coin: 리포트를 보여줄 대상 코인
 struct ReportView: View {
+    @Environment(\.horizontalSizeClass) var hSizeClass
+    @Environment(\.verticalSizeClass) var vSizeClass
     @StateObject var viewModel: ReportViewModel
     
     init(coin: Coin) {
@@ -21,7 +23,7 @@ struct ReportView: View {
     }
     
     var body: some View {
-        ScrollView {
+        let content =
             VStack(spacing: 16) {
                 Text(String.aiGeneratedContentNotice)
                     .font(.system(size: 11))
@@ -65,8 +67,21 @@ struct ReportView: View {
                         .padding(.bottom, 30)
                 }
             }
+        
+        if hSizeClass == .regular && vSizeClass == .regular {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("AI 리포트")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(.aiCoLabel)
+                
+                content
+            }
+        } else {
+            ScrollView(.vertical) {
+                content
+            }
+            .scrollIndicators(.hidden)
         }
-        .scrollIndicators(.hidden)
     }
 }
 

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -47,9 +47,7 @@ struct ReportView: View {
                 onCancel: { viewModel.cancelWeekly() },
                 onRetry: { viewModel.retryWeekly() }
             ) { value in
-                value
-                    .byCharWrapping
-                    .highlightTextForNumbersOperator()
+                Text(value.byCharWrapping)
             }
             
             ReportSectionView(
@@ -59,9 +57,7 @@ struct ReportView: View {
                 onCancel: { viewModel.cancelToday() },
                 onRetry: { viewModel.retryToday() }
             ) { value in
-                value
-                    .byCharWrapping
-                    .highlightTextForNumbersOperator()
+                Text(value.byCharWrapping)
             }
             
             if case .success = viewModel.today,

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -41,7 +41,7 @@ struct AIBriefingView: View {
                         .font(.system(size: 16, weight: .bold))
                         .foregroundStyle(value.sentiment.color(for: themeManager.selectedTheme))
                 } content: { value in
-                    Text(AttributedString(value.summary.byCharWrapping))
+                    Text(value.summary.byCharWrapping)
                 }
                 
                 ReportSectionView(
@@ -55,9 +55,7 @@ struct AIBriefingView: View {
                         .font(.system(size: 16, weight: .bold))
                         .foregroundStyle(value.sentiment.color(for: themeManager.selectedTheme))
                 } content: { value in
-                    value.summary
-                        .byCharWrapping
-                        .highlightTextForNumbersOperator()
+                    Text(value.summary.byCharWrapping)
                 }
                 
                 FearGreedView()

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -26,6 +26,8 @@ struct AIBriefingView: View {
             Text(String.aiGeneratedContentNotice)
                 .font(.system(size: 11))
                 .foregroundStyle(.aiCoNeutral)
+                .lineSpacing(5)
+                .frame(maxWidth: .infinity, alignment: .leading)
             
             VStack(spacing: 16) {
                 // FIXME: ViewType enum + struct -> 프로퍼티를 enum 값에 따라 전달

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -55,7 +55,9 @@ struct AIBriefingView: View {
                         .font(.system(size: 16, weight: .bold))
                         .foregroundStyle(value.sentiment.color(for: themeManager.selectedTheme))
                 } content: { value in
-                    Text(AttributedString(value.summary.byCharWrapping))
+                    value.summary
+                        .byCharWrapping
+                        .highlightTextForNumbersOperator()
                 }
                 
                 FearGreedView()

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -27,7 +27,6 @@ struct AIBriefingView: View {
                 .font(.system(size: 11))
                 .foregroundStyle(.aiCoNeutral)
                 .lineSpacing(5)
-                .frame(maxWidth: .infinity, alignment: .leading)
             
             VStack(spacing: 16) {
                 // FIXME: ViewType enum + struct -> 프로퍼티를 enum 값에 따라 전달


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- close #285 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- iPad 레이아웃 분기(Size class 기반)
    ```swift
    @Environment(\.horizontalSizeClass) var hSizeClass
    @Environment(\.verticalSizeClass) var vSizeClass
    
    if hSizeClass == .regular && vSizeClass == .regular {
        // iPad 환경(regular × regular) 전용 레이아웃
    } else {
        // iPhone 및 기타 환경
    }
    ```
- iPad에서는 상위 CoinDetailView가 전체 스크롤을 담당하므로 동일 방향 스크롤뷰 중첩을 피하도록 분기했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- CoinDetailView와 합친 후에 수정사항 생기면 추가로 작업할 예정입니다.