### PR TITLE
마켓 화면 아이폰에서 네비게이션 푸시되지 않던 버그 수정 & 디자인 적용

### DIFF
--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -73,6 +73,9 @@ struct MarketView: View {
                 .task {
                     await store.load()
                 }
+                .navigationDestination(item: $selectedCoin) { coin in
+                    CoinDetailView(coin: coin)
+                }
             }
             .navigationSplitViewColumnWidth(min: 400, ideal: 400, max: 400)
         } detail: {
@@ -83,7 +86,6 @@ struct MarketView: View {
             }
         }
         .navigationSplitViewStyle(.balanced) // 균등 분할
-        .navigationSplitViewStyle(.prominentDetail) // 디테일 뷰 강조
     }
 }
 

--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -37,11 +37,9 @@ struct MarketView: View {
                         .padding(.horizontal, 16)
 
                     if !records.isEmpty {
-                        RecentCoinSectionView(
-                            coins: records.compactMap { store.coinMeta[$0.query]
-                            }) { coin in
-                                selectedCoin = coin
-                            }
+                        RecentCoinSectionView(coins: records.compactMap { store.coinMeta[$0.query] }, deleteAction: { coin in
+                            viewModel.removeRecentSearchKeyword(coin)
+                        }) { coin in selectedCoin = coin }
                     }
                 }
 
@@ -91,7 +89,8 @@ struct MarketView: View {
 
 fileprivate struct RecentCoinSectionView: View {
     let coins: [Coin]
-    let action: (Coin) -> Void
+    let deleteAction: (Coin) -> Void
+    let tapAction: (Coin) -> Void
 
     var body: some View {
         ScrollView(.horizontal) {
@@ -99,16 +98,24 @@ fileprivate struct RecentCoinSectionView: View {
                 ForEach(coins) { coin in
                     HStack(spacing: 8) {
                         Text(coin.koreanName)
-                            .font(.caption)
+                            .font(.system(size: 14))
+
+                        Button {
+                            deleteAction(coin)
+                        } label: {
+                            Image(systemName: "xmark")
+                                .resizable()
+                                .frame(width: 10, height: 10)
+                                .foregroundStyle(.aiCoLabelSecondary)
+                        }
                     }
                     .padding(.vertical, 8)
                     .padding(.horizontal, 12)
                     .background {
                         Capsule().stroke(.defaultGradient, lineWidth: 0.5)
-
                     }
                     .onTapGesture {
-                        action(coin)
+                        tapAction(coin)
                     }
                 }
             }

--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -38,7 +38,7 @@ struct MarketView: View {
 
                     if !records.isEmpty {
                         RecentCoinSectionView(coins: records.compactMap { store.coinMeta[$0.query] }, deleteAction: { coin in
-                            viewModel.removeRecentSearchKeyword(coin)
+                            // TODO: 삭제 작업 필요
                         }) { coin in selectedCoin = coin }
                     }
                 }

--- a/AIProject/AIProject/Features/Search/SearchBarView.swift
+++ b/AIProject/AIProject/Features/Search/SearchBarView.swift
@@ -20,6 +20,7 @@ struct SearchBarView: View {
                     .padding(.horizontal, 8)
                     .focused($isFocused)
                     .submitLabel(.search)
+                    .font(.system(size: 14))
 
                 if !searchText.isEmpty {
                     CircleDeleteButton(fontSize: 9) {
@@ -31,7 +32,11 @@ struct SearchBarView: View {
             .padding(.vertical, 14)
             .background {
                 RoundedRectangle(cornerRadius: 15)
-                    .fill(.aiCoBackground)
+                    .fill(.aiCoBackgroundBlue)
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 15)
+                    .stroke(.accentGradient, lineWidth: 0.5)
             }
             .animation(.snappy(duration: 0.2), value: isFocused)
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 마켓 화면 아이폰에서 네비게이션 푸시 가능하도록 버그 수정
- 최근 검색, 검색바 디자인 적용

### 스크린샷 (선택)
<img width="489" height="974" alt="image" src="https://github.com/user-attachments/assets/545de750-8c91-40b2-80bf-54e0300285bd" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
