### PR TITLE
검색 기록 저장(오래된 기록) 자동 삭제 및 기록 삭제 메서드 추가

### DIFF
--- a/AIProject/AIProject/Domain/Interface/SearchRecordManaging.swift
+++ b/AIProject/AIProject/Domain/Interface/SearchRecordManaging.swift
@@ -12,12 +12,11 @@ protocol SearchRecordManaging {
     /// 새로운 검색 기록을 저장
     func save(query: String) throws
 
-    /// 최신 검색 기록을 불러옴
-    /// - Parameter limit: 가져올 최대 레코드 수(기본값 10으로 설정)
-    func fetchRecent(limit: Int) throws -> [SearchRecord]
-
-    /// 특정 검색 기록을 삭제
+    /// 특정 검색 기록(객체)을 삭제
     func delete(record: SearchRecord) throws
+
+    /// 특정 검색 기록(쿼리로) 삭제
+    func delete(query: String) throws
 
     /// 모든 검색 기록을 일괄 삭제
     func deleteAll() throws

--- a/AIProject/AIProject/Features/Market/MarketStore.swift
+++ b/AIProject/AIProject/Features/Market/MarketStore.swift
@@ -300,4 +300,8 @@ extension MarketStore {
     func addRecord(_ id: CoinID) {
         try? searchRecordManager.save(query: id)
     }
+
+    func deleteRecord(_ id: CoinID) {
+        try? searchRecordManager.delete(query: id)
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>


## 📝 작업 내용

- save할 때 maxCount기준(10)으로 timeStamp상 오래된 기록은 자동 삭제하고 저장하도록 바꿨습니다.
```swift
/// 검색 기록 최대 저장 수
private let maxCount = 10
```

```swift
let fetchAll: NSFetchRequest<SearchRecordEntity> = SearchRecordEntity.fetchRequest()
fetchAll.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
let all = try context.fetch(fetchAll)

// 초과된 기록(maxCount기준) 삭제
if all.count > maxCount {
    let excess = all.suffix(from: maxCount)
    for oldRecord in excess {
         service.delete(oldRecord)
    }
}
```



- MarketStore에 CoinID를 사용해 기록 삭제하는 메서드 추가해두었습니다.
```swift
extension MarketStore {
    func addRecord(_ id: CoinID) {
        try? searchRecordManager.save(query: id)
    }

    func deleteRecord(_ id: CoinID) {
        try? searchRecordManager.delete(query: id)
    }
}
```


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
