### PR TITLE
코인 상세 뷰 아이패드 대응

### DIFF
--- a/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
@@ -16,66 +16,69 @@ struct CoinDetailView: View {
     var body: some View {
         GeometryReader { proxy in
             ScrollView {
-                VStack(spacing: 12) {
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        if hSizeClass == .regular {
-                            // FIXME: HeaderView로 교체 필요
-                            Text(coin.koreanName)
-                                .font(.system(size: 24, weight: .black))
-                                .foregroundStyle(.aiCoLabel)
-                        } else {
+                VStack(spacing: 0) {
+                    // 헤더
+                    if hSizeClass == .regular {
+                        HStack(alignment: .lastTextBaseline) {
+                            HeaderView(heading: coin.koreanName) // FIXME: 코인 심볼
+                        }
+                    } else {
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
                             Text(coin.koreanName)
                                 .font(.system(size: 18, weight: .bold))
                                 .foregroundStyle(.aiCoLabel)
+                            
+                            Text(coin.coinSymbol)
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(.aiCoLabelSecondary)
+                            
+                            Spacer()
                         }
-                        
-                        Text(coin.coinSymbol)
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(.aiCoLabelSecondary)
-                        
-                        Spacer()
+                        .padding(EdgeInsets(top: 20, leading: 16, bottom: 16, trailing: 16))
                     }
-                    .padding(.bottom, 5)
-                    .padding(.horizontal, 16)
                     
-                    if hSizeClass == .compact {
-                        HStack(spacing: 8) {
-                            ForEach(Tab.allCases) { tab in
-                                RoundedRectangleButton(
-                                    title: tab.title,
-                                    isActive: selectedTab == tab
-                                ) {
-                                    withAnimation(.easeInOut(duration: 0.22)) {
-                                        selectedTab = tab
+                    
+                    VStack(spacing: 16) {
+                        // 버튼
+                        if hSizeClass == .compact {
+                            HStack(spacing: 16) {
+                                ForEach(Tab.allCases) { tab in
+                                    RoundedRectangleButton(
+                                        title: tab.title,
+                                        isActive: selectedTab == tab
+                                    ) {
+                                        withAnimation(.easeInOut(duration: 0.22)) {
+                                            selectedTab = tab
+                                        }
                                     }
                                 }
-                                .frame(height: 36)
+                                Spacer(minLength: 0)
                             }
-                            Spacer(minLength: 0)
                         }
-                        .padding(.bottom, 10)
-                        .padding(.horizontal, 16)
-                    }
-                    
-                    if hSizeClass == .regular {
-                        ChartView(coin: coin)
-                            .frame(height: proxy.size.height * 0.55)
                         
-                        ReportView(coin: coin)
-                            .padding(.top, 20)
-                    } else {
-                        switch selectedTab {
-                        case .chart:
+                        // 콘텐츠
+                        if hSizeClass == .regular {
                             ChartView(coin: coin)
-                                .frame(height: proxy.size.height * 0.8)
-                        case .report:
+                                .frame(height: proxy.size.height * 0.55)
+                            
                             ReportView(coin: coin)
+                                .padding(.top, 20)
+                        } else {
+                            switch selectedTab {
+                            case .chart:
+                                ChartView(coin: coin)
+                                    .frame(height: proxy.size.height * 0.8)
+                            case .report:
+                                ReportView(coin: coin)
+                            }
                         }
                     }
+                    .padding(.horizontal, 16)
                 }
-                .padding(.top, 20)
             }
+            .scrollIndicators(.hidden)
         }
+        //        .toolbar(.hidden, for: .navigationBar)
     }
 }
 
@@ -83,9 +86,9 @@ extension CoinDetailView {
     private enum Tab: Int, CaseIterable, Identifiable {
         case chart
         case report
-
+        
         var id: Int { rawValue }
-
+        
         var title: String {
             switch self {
             case .chart: return "차트"

--- a/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
@@ -8,65 +8,89 @@
 import SwiftUI
 
 struct CoinDetailView: View {
-    @State private var selectedTab = 0
+    @Environment(\.horizontalSizeClass) var hSizeClass
+    @State private var selectedTab: Tab = .chart
     
     let coin: Coin
     
-    private let tabs = ["차트", "AI 리포트"]
-    
     var body: some View {
-        VStack(spacing: 12) {
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text(coin.koreanName)
-                    .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(.aiCoLabel)
-
-                Text(coin.id)                        
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.aiCoLabelSecondary)
-
-                Spacer()
-            }
-            .padding(.bottom, 5)
-            
-            HStack(spacing: 8) {
-                ForEach(tabs.indices, id: \.self) { index in
-                    RoundedRectangleButton(
-                        title: tabs[index],
-                        isActive: selectedTab == index
-                    ) {
-                        selectedTab = index
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: 12) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        if hSizeClass == .regular {
+                            // FIXME: HeaderView로 교체 필요
+                            Text(coin.koreanName)
+                                .font(.system(size: 24, weight: .black))
+                                .foregroundStyle(.aiCoLabel)
+                        } else {
+                            Text(coin.koreanName)
+                                .font(.system(size: 18, weight: .bold))
+                                .foregroundStyle(.aiCoLabel)
+                        }
+                        
+                        Text(coin.coinSymbol)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(.aiCoLabelSecondary)
+                        
+                        Spacer()
                     }
-                    .frame(height: 36)
+                    .padding(.bottom, 5)
+                    .padding(.horizontal, 16)
+                    
+                    if hSizeClass == .compact {
+                        HStack(spacing: 8) {
+                            ForEach(Tab.allCases) { tab in
+                                RoundedRectangleButton(
+                                    title: tab.title,
+                                    isActive: selectedTab == tab
+                                ) {
+                                    withAnimation(.easeInOut(duration: 0.22)) {
+                                        selectedTab = tab
+                                    }
+                                }
+                                .frame(height: 36)
+                            }
+                            Spacer(minLength: 0)
+                        }
+                        .padding(.bottom, 10)
+                        .padding(.horizontal, 16)
+                    }
+                    
+                    if hSizeClass == .regular {
+                        ChartView(coin: coin)
+                            .frame(height: proxy.size.height * 0.55)
+                        
+                        ReportView(coin: coin)
+                            .padding(.top, 20)
+                    } else {
+                        switch selectedTab {
+                        case .chart:
+                            ChartView(coin: coin)
+                                .frame(height: proxy.size.height * 0.8)
+                        case .report:
+                            ReportView(coin: coin)
+                        }
+                    }
                 }
-                Spacer(minLength: 0)
+                .padding(.top, 20)
             }
-            .padding(.bottom, 10)
-            
-            ZStack(alignment: .topLeading) {
-                /// 차트 탭
-                ChartView(coin: coin)
-                    .opacity(selectedTab == 0 ? 1 : 0)
-                    .allowsHitTesting(selectedTab == 0)
-                    .accessibilityHidden(selectedTab != 0)
+        }
+    }
+}
 
-                /// AI 리포트 탭
-                ReportView(coin: coin)
-                    .opacity(selectedTab == 1 ? 1 : 0)
-                    .allowsHitTesting(selectedTab == 1)
-                    .accessibilityHidden(selectedTab != 1)
+extension CoinDetailView {
+    private enum Tab: Int, CaseIterable, Identifiable {
+        case chart
+        case report
+
+        var id: Int { rawValue }
+
+        var title: String {
+            switch self {
+            case .chart: return "차트"
+            case .report: return "AI 리포트"
             }
-            .animation(.easeInOut(duration: 0.15), value: selectedTab)
-
-             Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 20) 
-        .background(.aiCoBackground)
-        .safeAreaInset(edge: .top) {
-            Color.clear.frame(height: 80)
-        }
-        .safeAreaInset(edge: .bottom) {
-            Color.clear.frame(height: 40)
         }
     }
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -15,14 +15,10 @@ import SwiftUI
 ///   - coin: 리포트를 보여줄 대상 코인
 struct ReportView: View {
     @Environment(\.horizontalSizeClass) var hSizeClass
-    @Environment(\.verticalSizeClass) var vSizeClass
     @StateObject var viewModel: ReportViewModel
     
-    private var isPadLayout: Bool {
-        hSizeClass == .regular && vSizeClass == .regular
-    }
-    
     init(coin: Coin) {
+        print("reportViewinit")
         _viewModel = StateObject(wrappedValue: ReportViewModel(coin: coin))
     }
     
@@ -71,7 +67,7 @@ struct ReportView: View {
             }
         }
         
-        if isPadLayout {
+        if hSizeClass == .regular {
             VStack(alignment: .leading, spacing: 16) {
                 Text("AI 리포트")
                     .font(.system(size: 18, weight: .bold))
@@ -79,9 +75,11 @@ struct ReportView: View {
                 
                 content
             }
+            .padding(.horizontal, 16)
         } else {
             ScrollView(.vertical) {
                 content
+                    .padding(.horizontal, 16)
             }
             .scrollIndicators(.hidden)
         }
@@ -90,5 +88,5 @@ struct ReportView: View {
 
 #Preview {
     let sampleCoin = Coin(id: "KRW-BTC", koreanName: "비트코인")
-    return ReportView(coin: sampleCoin).padding(.horizontal, 16)
+    return ReportView(coin: sampleCoin)
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -18,13 +18,17 @@ struct ReportView: View {
     @StateObject var viewModel: ReportViewModel
     
     init(coin: Coin) {
-        print("reportViewinit")
         _viewModel = StateObject(wrappedValue: ReportViewModel(coin: coin))
     }
     
     var body: some View {
-        let content =
         VStack(alignment: .leading, spacing: 16) {
+            if hSizeClass == .regular {
+                Text("AI 리포트")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(.aiCoLabel)
+            }
+            
             Text(String.aiGeneratedContentNotice)
                 .font(.system(size: 11))
                 .foregroundStyle(.aiCoNeutral)
@@ -66,27 +70,10 @@ struct ReportView: View {
                     .padding(.bottom, 30)
             }
         }
-        
-        if hSizeClass == .regular {
-            VStack(alignment: .leading, spacing: 16) {
-                Text("AI 리포트")
-                    .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(.aiCoLabel)
-                
-                content
-            }
-            .padding(.horizontal, 16)
-        } else {
-            ScrollView(.vertical) {
-                content
-                    .padding(.horizontal, 16)
-            }
-            .scrollIndicators(.hidden)
-        }
     }
 }
 
 #Preview {
     let sampleCoin = Coin(id: "KRW-BTC", koreanName: "비트코인")
-    return ReportView(coin: sampleCoin)
+    return ScrollView { ReportView(coin: sampleCoin).padding(.horizontal, 16) }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- close #186 
    - close #310 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 코인 상세 뷰
    - 아이폰, 아이패드 상관없이 전체를 스크롤뷰로 감쌌습니다.
    - 차트의 경우 아이폰은 80%, 아이패드는 55%의 비율로 표시되도록 설정했습니다.
    - 아이패드에서 헤더 옆 코인 심볼은 HeaderView 업데이트 후 수정할 예정입니다.

### 스크린샷 (선택)
<table>
<td><img width="513" height="688" alt="image" src="https://github.com/user-attachments/assets/42d4790c-8fa6-4691-b972-d69f944e423b" /></td>
<td><img width="688" height="513" alt="image" src="https://github.com/user-attachments/assets/1d789880-d677-4c68-9ecc-a47f642cb983" /></td>
</table>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- CoinDetailView 코드가 분기가 중간중간 들어가면서 어떤 흐름인지 잘 안보이는 것 같은데, 좋은 개선 방법이 있을까요?