### PR TITLE
코인 상세 - 차트 갱신 시 오른쪽 봉만 업데이트 + ProgressView 표시 개선

### DIFF
--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -82,8 +82,13 @@ struct ChartView: View {
             chartArea
         }
         .padding(20)
-        .onAppear { viewModel.checkBookmark() }
-        .onDisappear { viewModel.stopUpdating() }
+        .onAppear {
+            viewModel.checkBookmark()
+            viewModel.retry()
+        }
+        .onDisappear {
+            viewModel.stopUpdating()
+        }
         .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(Color.aiCoBackground)

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -194,23 +194,25 @@ private struct CandleChartView: View {
     let negativeColor: Color
     
     var body: some View {
-        Chart(data) { point in
-            /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
-            RuleMark(
-                x: .value("Date", point.date),
-                yStart: .value("Low", point.low),
-                yEnd: .value("High", point.high)
-            )
-            .foregroundStyle( point.close >= point.open ? positiveColor : negativeColor )
-            
-            /// 시가/종가 직사각형 (실체 바)
-            RectangleMark(
-                x: .value("Date", point.date),
-                yStart: .value("Open", point.open),
-                yEnd: .value("Close", point.close),
-                width: 6
-            )
-            .foregroundStyle( point.close >= point.open ? positiveColor : negativeColor )
+        Chart {
+            ForEach(data, id: \.date) { point in
+                /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
+                RuleMark(
+                    x: .value("Date", point.date),
+                    yStart: .value("Low", point.low),
+                    yEnd: .value("High", point.high)
+                )
+                .foregroundStyle( point.close >= point.open ? positiveColor : negativeColor )
+                
+                /// 시가/종가 직사각형 (실체 바)
+                RectangleMark(
+                    x: .value("Date", point.date),
+                    yStart: .value("Open", point.open),
+                    yEnd: .value("Close", point.close),
+                    width: 6
+                )
+                .foregroundStyle( point.close >= point.open ? positiveColor : negativeColor )
+            }
         }
         /// X축 도메인 설정 및 스크롤 위치 초기화
         .chartXScale(domain: xDomain)

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -263,9 +263,9 @@ final class ChartViewModel: ObservableObject {
                 } else if d > (prices.last?.date ?? .distantPast) {
                     prices.append(newPrice) // 더 뒤 시각이면 추가
                 } else {
-                    // 과거 데이터면 무시
+                    /// 과거 데이터면 무시
                     #if DEBUG
-                    print("과거 캔들 무시:", d)
+                    print("과거 캔들 무시 - ", d)
                     #endif
                 }
             }
@@ -287,11 +287,12 @@ final class ChartViewModel: ObservableObject {
             /// 마지막 갱신 시각 설정
             lastUpdated = prices.last?.date
         } catch is CancellationError {
-            // 조용히 무시
-        } catch {
-            // 주기 갱신 실패는 UI를 실패 상태로 바꾸지 않음 (스피너/깜빡임 방지)
             #if DEBUG
-            print("증분 갱신 실패: \(error)")
+            print("증분 갱신 취소 - market=\(coinSymbol), last=\(String(describing: prices.last?.date)), count=\(prices.count)")
+            #endif
+        } catch {
+            #if DEBUG
+            print("증분 갱신 실패 - \(error)")
             #endif
         }
     }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -300,11 +300,11 @@ final class ChartViewModel: ObservableObject {
             lastUpdated = prices.last?.date
         } catch is CancellationError {
             #if DEBUG
-            print("증분 갱신 취소 - market=\(coinSymbol), last=\(String(describing: prices.last?.date)), count=\(prices.count)")
+            print("[ChartVM] refreshLatestCandles cancelled - market=\(coinSymbol), last=\(String(describing: prices.last?.date)), count=\(prices.count)")
             #endif
         } catch {
             #if DEBUG
-            print("증분 갱신 실패 - \(error)")
+            print("refreshLatestCandles failed - \(error)")
             #endif
         }
     }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -210,6 +210,12 @@ final class ChartViewModel: ObservableObject {
     
     private func refreshLatestCandles() async {
         do {
+            /// 초기에 로딩 실패 후(네트워크 등) prices가 비어있는 상태면 전체 24h 로드
+            if prices.isEmpty {
+                await loadPrices(showLoading: false)
+                return
+            }
+            
             let market = coinSymbol
             let lastDate = prices.last?.date // 마지막 봉 시각
 

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -225,6 +225,12 @@ final class ChartViewModel: ObservableObject {
                 guard let last = lastDate else { return 2 }
                 return max(2, min(200, Int(Date().timeIntervalSince(last) / 60) + 1))
             }()
+            
+            /// 갭이 200분보다 크면 전체 24h 리로드
+            if gapMinutes > 200 {
+                await loadPrices(showLoading: false)
+                return
+            }
 
             /// 최신 분봉들 N개
             let latestDTOs = try await tickerAPI.fetchCandles(id: market, count: gapMinutes)

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -103,6 +103,9 @@ final class ChartViewModel: ObservableObject {
     
     /// 네트워크/루프 중단
     func stopUpdating() {
+        #if DEBUG
+        print("[ChartVM] stopUpdating() — cancel loop for \(coinSymbol)")
+        #endif
         updateTask?.cancel()
         updateTask = nil
     }
@@ -194,8 +197,14 @@ final class ChartViewModel: ObservableObject {
             
             if showLoading { status = .success }
         } catch is CancellationError {
+            #if DEBUG
+            print("[ChartVM] loadPrices cancelled — market=\(coinSymbol), last=\(String(describing: prices.last?.date)), count=\(prices.count)")
+            #endif
             return
         } catch NetworkError.taskCancelled {
+            #if DEBUG
+            print("[ChartVM] loadPrices taskCancelled — market=\(coinSymbol)")
+            #endif
             return
         } catch {
             let err = (error as? NetworkError)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #293 

## 📝 작업 내용

- **ProgressView 표시 개선**
  - **초기 로드 / 사용자 재시도:** `showLoading = true` → `ProgressView` 표시
  - **주기 갱신 (백그라운드 / 자동 새로고침):** `showLoading = false` → `ProgressView` 미표시
 
  **→ 주기 갱신 중엔 `ProgressView` 미노출 → 사용자 체감 깜빡임 없음**

</br>

- **차트 갱신 시 오른쪽 봉만 업데이트**
  - Chart 데이터 루프를 `ForEach`로 전환
   : 각 봉의 `identity` 명시 
  **→ 변경된 항목(오른쪽 봉)만 렌더링, 전체 재그림을 방지** 

  - `refreshLatestCandles()` 추가
  : 백그라운드 체류 후 복귀 시 비어있는 분 수를 계산하여 메우는 메서드
      -  **갭 계산:** 최소 2개 ~ 최대 200개의 최신 분봉을 조회하여 비교 
        - 최소 2개: 진행 중 분 (교체 용) + 다음 분 (추가 용) 대비
        - 최대 200개: API 호출 제한 (200개 초과 시 / 빈 데이터 시 전체 그래프 로드)
      (* 봉의 특징: 1분봉은 해당 분이 ‘닫혀야’ 확정됨. 해당 ‘분’이 닫히기 전까지 값이 확정이 아님
      그 1분 동안 체결이 계속 들어오면 high/low/close/거래대금이 바뀜)
      → 보통 다음 분에 직전 봉이 반영됨 (거래가 없으면 그 분 봉 자체가 없을 수도 있음)

    - **병합 규칙**
      - 동일 타임스탬프 → 교체(replace)
      - 더 뒤 타임스탬프 → 추가(append)
      - 24시간 외 과거 타임스탬프 → 무시(DEBUG 로그만)


**- 차트 동작 흐름**
1. 화면 진입 → `loadPrices(showLoading: true)` (`ProgressView` 1회)
2. 이후 매 60초 → `refreshLatestCandles()` (`ProgressView` 없음)
3. 복귀 시 공백이 크면
    *` ≤200분`: 최신 N개로 채움
    *` 200분`:(`ProgressView` 없이) 24h 재로드 


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

경우의 수를 적어놨습니다. 궁금하신 분들은 참고하여 테스트 해보시면 되겠습니다.

**1. 초기 로딩** 
  - 첫 진입에만 `ProgressView` 1회 노출
  - 1분 후 갱신 때는 `ProgressView` 재등장 없음
 
**2. 1분 주기: 오른쪽 마지막 봉만 갱신**
  - 차트 열린 채로 1~2분 대기→ 마지막 봉만 값이 바뀌거나 또는 1개만 추가
  - 헤더(가격/등락률/거래대금)는 조용히 숫자만 변함 (화면 깜빡임 X)

**3. 네비게이션/취소(수명) 안정성**
  - 차트 화면 재진입 시 ‘작업 취소’ 또는 무한 로딩 없이 즉시 데이터 표시
   `[ChartVM]`로 시작하는 로그 (`stopUpdating()` / `loadPrices cancelled` / `refreshLatestCandles cancelled`) 보이면 OK

**4. 백그라운드 → 짧은 공백(예: 5~10분)**
  - 홈으로 나갔다가 5~10분 뒤 복귀 → `ProgressView` 없이 누락된 분 수만큼 한꺼번에 교체/추가 반영
  -  헤더 수치 갱신 (화면 깜빡임 X)

**5. 긴 공백(>200분) 시 24h 재로드**
  - `ProgressView` 없이 24h 데이터로 전체 재로드
  -  콘솔에 별도 에러/취소 UI 로그 없음

**6. 취소/수명**
  - 차트 화면에서 다른 화면으로 빠르게 이동 → Xcode 콘솔에 취소/해제 로그(deinit / cancelled)만 찍힘
  - 앱 UI는 안정적으로 유지

**7. 에러 내성(네트워크 불안정)**
  - 차트 화면에서 Wi-Fi 토글 OFF → 10초 대기 → ON 후 1~2분 관찰 
  에러 동안에도 현재 차트 그대로 유지 (`ProgressView`/에러 화면 노출 X)
  이후 틱에서 자동 회복하여 정상 갱신 재개