### PR TITLE
[hotfix] 디버깅용으로 추가했던 배경색 제거

### DIFF
--- a/AIProject/AIProject/Features/Dashboard/CardConst.swift
+++ b/AIProject/AIProject/Features/Dashboard/CardConst.swift
@@ -12,5 +12,5 @@ enum CardConst {
     static let cardHeightMultiplier: CGFloat = 0.9
     static let headerHeight: CGFloat = 200
     static let headerContentSpacing: CGFloat = 30
-    static let cardInnerPadding: CGFloat = 24
+    static let cardInnerPadding: CGFloat = 16
 }

--- a/AIProject/AIProject/Features/Dashboard/View/RecommendCardView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/RecommendCardView.swift
@@ -57,7 +57,6 @@ struct RecommendCardView: View {
                 .padding(.top, 0.2)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.red.opacity(0.1))
 
             VStack {
                 Text(recommendCoin.comment.byCharWrapping)
@@ -66,8 +65,7 @@ struct RecommendCardView: View {
                     .foregroundStyle(.aiCoLabel)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, .spacing)
-            .background(.blue.opacity(0.1))
+            .padding(.top, 32)
         }
         .padding(24)
         .background(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

이전 PR에서 디버깅용으로 깔아둔 배경색을 못보고 머지를 해버렸네요 죄송합니다!!

<img width="200" alt="image" src="https://github.com/user-attachments/assets/e4e13a89-7520-43ea-9fa6-77f773772e98" />


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
