### PR TITLE
'차트' 버튼 '시세'로 변경, 공포탐욕지수 cornerRadius 수정

### DIFF
--- a/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
@@ -91,7 +91,7 @@ extension CoinDetailView {
         
         var title: String {
             switch self {
-            case .chart: return "차트"
+            case .chart: return "시세"
             case .report: return "AI 리포트"
             }
         }

--- a/AIProject/AIProject/Features/Dashboard/View/FearGreedView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/FearGreedView.swift
@@ -14,7 +14,7 @@ struct FearGreedView: View {
     @Environment(\.colorScheme) private var colorScheme
     @StateObject private var viewModel: FearGreedViewModel
     
-    private static let cornerRadius: CGFloat = 10
+    private static let cornerRadius: CGFloat = 20
     
     init(viewModel: FearGreedViewModel = FearGreedViewModel()) {
         _viewModel = StateObject(wrappedValue: viewModel)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- [아이폰] 코인 상세에서 '차트' -> '시세'로 버튼 이름 변경
- 공포탐욕지수 cornerRadius 다른 view와 통일

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- 없습니다!