### PR TITLE
챗봇 버그 수정

### DIFF
--- a/AIProject/AIProject/Core/Remote/HTTP/ChatBotClient.swift
+++ b/AIProject/AIProject/Core/Remote/HTTP/ChatBotClient.swift
@@ -108,8 +108,19 @@ extension ChatBotClient: URLSessionDataDelegate {
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
         if let error {
+            print("챗봇 에러 \(error.localizedDescription)")
             continuation?.finish(throwing: error)
             disconnect()
         }
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse) async -> URLSession.ResponseDisposition {
+        if let httpResponse = response as? HTTPURLResponse {
+            if (200..<300) ~= httpResponse.statusCode {
+                return .allow
+            }
+        }
+
+        return .cancel
     }
 }

--- a/AIProject/AIProject/Features/ChatBot/View/ChatScrollView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/ChatScrollView.swift
@@ -21,6 +21,7 @@ struct ChatScrollView<Content: View>: View {
     @State private var viewportHeight: CGFloat = .zero
     @State private var scrollOffSet: CGFloat = .zero
     @State private var contentHeight: CGFloat = .zero
+
     @Namespace private var coordinateSpaceName: Namespace.ID
     @ViewBuilder private var content: () -> Content
 
@@ -67,7 +68,16 @@ struct ChatScrollView<Content: View>: View {
                     }
             }
         }
-        .scrollDismissesKeyboard(.interactively)
+        .simultaneousGesture(
+            DragGesture().updating($isDragging) { _, state, _ in
+                state = true
+            }
+            .onEnded { drag in
+                if drag.translation.height > 50 {
+                    viewModel.isTapped.toggle()
+                }
+            }
+        )
         .contentMargins(.vertical, 16)
         .coordinateSpace(name: coordinateSpaceName)
         .background(

--- a/AIProject/AIProject/Features/ChatBot/View/ChatScrollView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/ChatScrollView.swift
@@ -69,13 +69,12 @@ struct ChatScrollView<Content: View>: View {
             }
         }
         .simultaneousGesture(
-            DragGesture().updating($isDragging) { _, state, _ in
-                state = true
-            }
-            .onEnded { drag in
-                if drag.translation.height > 50 {
+            DragGesture().updating($isDragging) { drag, state, _ in
+                if drag.translation.height > 100 {
                     viewModel.isTapped.toggle()
                 }
+
+                state = true
             }
         )
         .contentMargins(.vertical, 16)

--- a/AIProject/AIProject/Features/ChatBot/ViewModel/ChatBotViewModel.swift
+++ b/AIProject/AIProject/Features/ChatBot/ViewModel/ChatBotViewModel.swift
@@ -14,9 +14,9 @@ final class ChatBotViewModel: ObservableObject {
     @Published private(set) var messages: [ChatMessage] = []
     /// 현재 유저가 메세지를 전송할 수 있는지 상태를 기록합니다.
     @Published private(set) var isEditable: Bool = false
-    /// 메세지 전송시에 변경되는 프로터입니다.
+    /// 메세지가 전송되고 화면에 메세지가 나타났을 때 트리거되는 프로퍼티입니다.
     @Published private(set) var isReceived: Bool = false
-	/// 현재 챗봇이 데이터를 스트림하는지 상태를 기록합니다.
+	/// 현재 챗봇이 데이터를 스트림하고 있는 중인지 상태를 기록합니다.
     @Published private(set) var isStreaming: Bool = false {
         didSet {
             Task { @MainActor in


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

- #292 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- **챗봇 스크롤시에 키보드가 간혹 내려가지 않는 버그 수정**

SwiftUI에서 제공하는 `.scrollDismissesKeyboard(.interactively)` 를 사용했었는데 해당 기능이 가끔씩 키보드를 내려주지 않는 문제가 있었습니다. 멘토님도 이런 경우 직접 구현하는걸 추천하셔서 직접 제스쳐를 확인하고 키보드를 내리도록 구현했습니다.

```swift
.simultaneousGesture(
    DragGesture().updating($isDragging) { _, state, _ in
        state = true
    }
    .onEnded { drag in
        if drag.translation.height > 50 {
            viewModel.isTapped.toggle()
        }
    }
)
```

- **챗봇 클라이언트가 응답코드를 검증하도록 수정**

응답 코드가 정상적이지 않을 때 챗봇이 먹통이 되는 문제를 확인했습니다.

원래 사용하고 있었던 델리게이트 메소드에서 응답 코드가 정상적이지 않을 때는 에러를 던져주는 줄 알았지만, **해당 메소드는 응답 코드 자체가 오지 않을때만 에러를 던지는 것을 알게되었습니다.**
```swift
func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?)
```

그래서 직접 응답 코드를 받을 수 있는 델리게이트 메소드가 있어서 해당 메소드를 통해 응답 코드를 검증했습니다.
```swift
func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse) async -> URLSession.ResponseDisposition
```

응답 코드 검증은 다음과 같이 진행했습니다.
```swift
func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse) async -> URLSession.ResponseDisposition {
    if let httpResponse = response as? HTTPURLResponse {
        if (200..<300) ~= httpResponse.statusCode {
            return .allow
        }
    }

    return .cancel
}
```

### 스크린샷 (선택)
아래로 스크롤시에 키보드가 내려가는 영상입니다.

https://github.com/user-attachments/assets/d638ee35-85d8-4430-92a1-d3c9fb99fe2b



## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 현재 응답 코드를 매우 간단히 받고 있는데, 세분화할 필요가 있을까요? 
   사용자 입장에서 자세한 에러를 알 필요가 없다고 판단하여 현재 응답 코드가 정상인지만 판단했습니다.
   