### PR TITLE
Report/Insight ViewModel 리팩토링

### DIFF
--- a/AIProject/AIProject/Core/Util/TaskResultHandler.swift
+++ b/AIProject/AIProject/Core/Util/TaskResultHandler.swift
@@ -1,0 +1,46 @@
+//
+//  TaskResultHandler.swift
+//  AIProject
+//
+//  Created by 장지현 on 8/25/25.
+//
+
+import Foundation
+
+enum TaskResultHandler {
+    /// 주어진 네트워크 `Task`의 결과를 변환하고 상태로 반영하는 유틸리티 메서드입니다.
+    ///
+    /// - Parameters:
+    ///   - task: 실행할 네트워크 Task
+    ///   - transform: Task 성공 결과(`Success`)를 출력 타입(`Output`)으로 변환하는 비동기 클로저
+    ///   - update: 변환된 결과 상태(`FetchState`)를 메인 스레드에서 속성에 반영하는 클로저
+    ///   - sideEffect: 선택적으로, 성공 시 원본 결과(`Success`)를 활용해 메인 스레드에서 UI를 갱신하는 클로저
+    static func applyResult<Success, Output>(
+        of task: Task<Success, Error>?,
+        using transform: @Sendable (Success) async throws -> Output,
+        update: @escaping (FetchState<Output>) -> Void,
+        sideEffect: ((Success) -> Void)? = nil
+    ) async {
+        do {
+            let value = try await task?.value
+            if let value {
+                let output = try await transform(value)
+                await MainActor.run { update(.success(output)) }
+                if let sideEffect {
+                    await MainActor.run { sideEffect(value) }
+                }
+            }
+        } catch {
+            if error.isTaskCancellation {
+                await MainActor.run { update(.cancel(.taskCancelled)) }
+                return
+            }
+            if let ne = error as? NetworkError {
+                print(ne.log())
+                await MainActor.run { update(.failure(ne)) }
+            } else {
+                print(error)
+            }
+        }
+    }
+}

--- a/AIProject/AIProject/Data/API/Alan/DTO/Content/CoinOverviewDTO.swift
+++ b/AIProject/AIProject/Data/API/Alan/DTO/Content/CoinOverviewDTO.swift
@@ -20,3 +20,28 @@ struct CoinOverviewDTO: Codable {
     /// 디지털 자산 소개
     let description: String
 }
+
+extension CoinOverviewDTO {
+    var overview: AttributedString {
+        var overview = AttributedString()
+        overview.append(AttributedString("- 심볼: \(symbol)\n"))
+        
+        if let urlString = self.websiteURL, let url = URL(string: urlString) {
+            let prefix = AttributedString("- 웹사이트: ")
+            var link = AttributedString(URL(string: urlString)?.host ?? urlString)
+            link.link = url
+            link.foregroundColor = .aiCoAccent
+            link.underlineStyle = .single
+            overview.append(prefix)
+            overview.append(link)
+            overview.append(AttributedString("\n"))
+        } else {
+            overview.append(AttributedString("- 웹사이트: 없음\n"))
+        }
+        
+        overview.append(AttributedString("- 최초발행: \(launchDate)\n"))
+        overview.append(AttributedString("- 소개: \(description.byCharWrapping)"))
+        
+        return overview
+    }
+}

--- a/AIProject/AIProject/Data/API/Alan/DTO/Content/CoinTodayNewsDTO.swift
+++ b/AIProject/AIProject/Data/API/Alan/DTO/Content/CoinTodayNewsDTO.swift
@@ -14,3 +14,9 @@ struct CoinTodayNewsDTO: Codable {
     /// 뉴스 배열, 3개
     let articles: [CoinArticleDTO]
 }
+
+extension CoinTodayNewsDTO {
+    var today: AttributedString {
+        AttributedString(summaryOfTodaysMarketSentiment.byCharWrapping)
+    }
+}

--- a/AIProject/AIProject/Data/API/Alan/DTO/Content/CoinWeeklyDTO.swift
+++ b/AIProject/AIProject/Data/API/Alan/DTO/Content/CoinWeeklyDTO.swift
@@ -17,3 +17,13 @@ struct CoinWeeklyDTO: Codable {
     /// 지난 일주일간 가격 추이와 거래량 변화의 주요 원인
     let reason: String
 }
+
+extension CoinWeeklyDTO {
+    var weekly: AttributedString {
+        AttributedString("""
+        - 가격 추이: \(priceTrend)
+        - 거래량 변화: \(volumeChange)
+        - 원인: \(reason)
+        """.byCharWrapping)
+    }
+}

--- a/AIProject/AIProject/Data/API/Reddit/DTO/RedditResponseDTO.swift
+++ b/AIProject/AIProject/Data/API/Reddit/DTO/RedditResponseDTO.swift
@@ -27,5 +27,27 @@ struct RedditDTO: Codable {
                 }
             }
         }
+
+        typealias Posts = [RedditPostDTO]
+    }
+}
+
+
+extension RedditDTO.RedditResponseDTO.Posts {
+    /// Reddit 게시글 데이터 배열을 제목과 내용으로 정리한 문자열입니다.
+    ///
+    /// 각 게시글의 제목과 본문을 순서대로 결합하여, AI 요약 요청에 전달할 수 있는 하나의 문자열로 만듭니다.
+    ///
+    /// - Returns: 게시글 제목과 내용을 포함한 요약 문자열
+    var communitySummary: String {
+        self.enumerated().reduce(into: "") { result, element in
+            let (index, item) = element
+            result += "제목\(index): \(item.data.title)"
+            if !item.data.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                result += "\n내용\(index): \(item.data.content)"
+            }
+            result += "\n"
+        }
+        .trimmingCharacters(in: .newlines)
     }
 }

--- a/AIProject/AIProject/Features/Base/ReportSectionView.swift
+++ b/AIProject/AIProject/Features/Base/ReportSectionView.swift
@@ -7,6 +7,15 @@
 
 import SwiftUI
 
+struct ReportSectionData<Value>: Identifiable {
+    let id: String
+    let icon: String
+    let title: String
+    let state: FetchState<Value>
+    let onCancel: () -> Void
+    let onRetry: () -> Void
+}
+
 struct ReportSectionView<Value, Trailing: View, Content: View>: View {
     let icon: String
     let title: String

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -34,34 +34,15 @@ struct ReportView: View {
                 .foregroundStyle(.aiCoNeutral)
                 .lineSpacing(5)
             
-            ReportSectionView(
-                icon: "text.page.badge.magnifyingglass",
-                title: "한눈에 보는 \(viewModel.koreanName)",
-                state: viewModel.overview,
-                onCancel: { viewModel.cancelOverview() },
-                onRetry: { viewModel.retryOverview() }
-            ) { value in
-                Text(value)
-            }
-            
-            ReportSectionView(
-                icon: "calendar",
-                title: "주간 동향",
-                state: viewModel.weekly,
-                onCancel: { viewModel.cancelWeekly() },
-                onRetry: { viewModel.retryWeekly() }
-            ) { value in
-                Text(value.byCharWrapping)
-            }
-            
-            ReportSectionView(
-                icon: "shareplay",
-                title: "오늘 시장의 분위기",
-                state: viewModel.today,
-                onCancel: { viewModel.cancelToday() },
-                onRetry: { viewModel.retryToday() }
-            ) { value in
-                Text(value.byCharWrapping)
+            ForEach(viewModel.sectionDataSource) { data in
+                ReportSectionView(
+                    icon: data.icon,
+                    title: data.title,
+                    state: data.state,
+                    onCancel: data.onCancel,
+                    onRetry: data.onRetry,
+                    content: { Text($0) }
+                )
             }
             
             if case .success = viewModel.today,

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -48,9 +48,9 @@ struct ReportView: View {
             if case .success = viewModel.today,
                !viewModel.news.allSatisfy({ $0.title.isEmpty && $0.summary.isEmpty }) {
                 ReportNewsSectionView(articles: viewModel.news)
-                    .padding(.bottom, 30)
             }
         }
+        .padding(.bottom, 30)
     }
 }
 

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
@@ -22,8 +22,8 @@ import Foundation
 ///   - news: 오늘의 뉴스 기사 목록
 final class ReportViewModel: ObservableObject {
     @Published var overview: FetchState<AttributedString> = .loading
-    @Published var weekly: FetchState<String> = .loading
-    @Published var today: FetchState<String> = .loading
+    @Published var weekly: FetchState<AttributedString> = .loading
+    @Published var today: FetchState<AttributedString> = .loading
     @Published var news: [CoinArticle] = [CoinArticle(title: "", summary: "AI가 정보를 준비하고 있어요", newsSourceURL: "https://example.com/")]
     
     let coin: Coin
@@ -53,6 +53,7 @@ final class ReportViewModel: ObservableObject {
         }
         
         overviewTask = Task { try await alanAPIService.fetchOverview(for: coin) }
+        
         weeklyTask = Task { [weak self] in
             try await withTaskCancellationHandler(
                 operation: {
@@ -294,5 +295,35 @@ final class ReportViewModel: ObservableObject {
     
     deinit {
         cancelAll()
+    }
+}
+extension ReportViewModel {
+    var sectionDataSource: [ReportSectionData<AttributedString>] {
+        [
+            ReportSectionData(
+                id: "overview",
+                icon: "text.page.badge.magnifyingglass",
+                title: "한눈에 보는 \(koreanName)",
+                state: overview,
+                onCancel: { self.cancelOverview() },
+                onRetry: { self.retryOverview() }
+            ),
+            ReportSectionData(
+                id: "weekly",
+                icon: "calendar",
+                title: "주간 동향",
+                state: weekly,
+                onCancel: { self.cancelWeekly() },
+                onRetry: { self.retryWeekly() }
+            ),
+            ReportSectionData(
+                id: "today",
+                icon: "shareplay",
+                title: "오늘 시장의 분위기",
+                state: today,
+                onCancel: { self.cancelToday() },
+                onRetry: { self.retryToday() }
+            ),
+        ]
     }
 }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
@@ -17,8 +17,8 @@ import Foundation
 ///
 /// - Properties:
 ///   - overview: 코인 개요 상태(`FetchState<AttributedString>`)
-///   - weekly: 주간 동향 상태(`FetchState<String>`)
-///   - today: 오늘의 시장 요약 상태(`FetchState<String>`)
+///   - weekly: 주간 동향 상태(`FetchState<AttributedString>`)
+///   - today: 오늘의 시장 요약 상태(`FetchState<AttributedString>`)
 ///   - news: 오늘의 뉴스 기사 목록
 final class ReportViewModel: ObservableObject {
     @Published var overview: FetchState<AttributedString> = .loading
@@ -42,7 +42,6 @@ final class ReportViewModel: ObservableObject {
         load()
     }
     
-    // 코인 개요, 주간 동향, 오늘 시장 요약/뉴스를 동시에 로드
     private func load() {
         cancelAll()
         
@@ -141,7 +140,6 @@ final class ReportViewModel: ObservableObject {
     func cancelWeekly() { weeklyTask?.cancel() }
     func cancelToday() { todayTask?.cancel() }
     
-    // 전체 Task 취소
     func cancelAll() {
         overviewTask?.cancel()
         weeklyTask?.cancel()

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -60,6 +60,11 @@ struct AIBriefingView: View {
                 state: data.state,
                 onCancel: data.onCancel,
                 onRetry: data.onRetry,
+                trailing: {
+                    Text($0.sentiment.rawValue)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundStyle($0.sentiment.color(for: themeManager.selectedTheme))
+                },
                 content: { Text($0.summary.byCharWrapping) }
             )
         }

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -53,33 +53,15 @@ struct AIBriefingView: View {
     
     @ViewBuilder
     private var briefingView: some View {
-        // FIXME: ViewType enum + struct -> 프로퍼티를 enum 값에 따라 전달
-        ReportSectionView(
-            icon: "bitcoinsign.bank.building",
-            title: "전반적인 시장의 분위기",
-            state: viewModel.overall,
-            onCancel: { viewModel.cancelOverall() },
-            onRetry: { viewModel.retryOverall() }
-        ) { value in
-            Text(value.sentiment.rawValue)
-                .font(.system(size: 16, weight: .bold))
-                .foregroundStyle(value.sentiment.color(for: themeManager.selectedTheme))
-        } content: { value in
-            Text(AttributedString(value.summary.byCharWrapping))
-        }
-        
-        ReportSectionView(
-            icon: "shareplay",
-            title: "주요 커뮤니티의 분위기",
-            state: viewModel.community,
-            onCancel: { viewModel.cancelCommunity() },
-            onRetry: { viewModel.retryCommunity() }
-        ) { value in
-            Text(value.sentiment.rawValue)
-                .font(.system(size: 16, weight: .bold))
-                .foregroundStyle(value.sentiment.color(for: themeManager.selectedTheme))
-        } content: { value in
-            Text(AttributedString(value.summary.byCharWrapping))
+        ForEach(viewModel.sectionDataSource) { data in
+            ReportSectionView(
+                icon: data.icon,
+                title: data.title,
+                state: data.state,
+                onCancel: data.onCancel,
+                onRetry: data.onRetry,
+                content: { Text($0.summary.byCharWrapping) }
+            )
         }
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
@@ -169,5 +169,25 @@ final class InsightViewModel: ObservableObject {
 
 extension InsightViewModel {
             }
+extension InsightViewModel {
+    var sectionDataSource: [ReportSectionData<Insight>] {
+        [
+            ReportSectionData(
+                id: "overall",
+                icon: "bitcoinsign.bank.building",
+                title: "전반적인 시장의 분위기",
+                state: overall,
+                onCancel: { self.cancelOverall() },
+                onRetry: { self.retryOverall() }
+            ),
+            ReportSectionData(
+                id: "community",
+                icon: "shareplay",
+                title: "주요 커뮤니티의 분위기",
+                state: community,
+                onCancel: { self.cancelCommunity() },
+                onRetry: { self.retryCommunity() }
+            ),
+        ]
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
@@ -168,22 +168,6 @@ final class InsightViewModel: ObservableObject {
 }
 
 extension InsightViewModel {
-    /// Reddit 게시글 데이터 배열을 요약 문자열로 변환합니다.
-    ///
-    /// 각 게시글의 제목과 본문을 순서대로 결합하여, AI 요약 요청에 전달할 수 있는 하나의 문자열로 만듭니다.
-    ///
-    /// - Parameter data: Reddit 게시글 DTO 배열
-    /// - Returns: 게시글 제목과 내용을 포함한 요약 문자열
-    fileprivate func makeCommunitySummary(from data: [RedditDTO.RedditResponseDTO.RedditPostDTO]) -> String {
-        data.enumerated().reduce(into: "") { result, element in
-            let (index, item) = element
-            
-            result += "제목\(index): \(item.data.title)"
-            if !item.data.content.isEmpty {
-                result += "\n내용\(index): \(item.data.content)"
             }
-            result += "\n"
-        }
-        .trimmingCharacters(in: .newlines)
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
@@ -29,7 +29,6 @@ final class InsightViewModel: ObservableObject {
         load()
     }
     
-    // 전체 분위기와 커뮤니티 분위기를 동시에 로드
     private func load() {
         cancelAll()
         
@@ -107,29 +106,23 @@ final class InsightViewModel: ObservableObject {
     
     func cancelOverall() {
         overallTask?.cancel()
-        
-        // 취소 UI 업데이트 -> 그럼 취소 확인은?
     }
     
     func cancelCommunity() {
         communityTask?.cancel()
     }
     
-    // TODO: 탭 전환시 자동 cancel
-    // 전체 Task 취소
     func cancelAll() {
         overallTask?.cancel()
         communityTask?.cancel()
     }
     
-    // TODO: 언제 deinit되는지 확인해보기
     deinit {
         cancelAll()
     }
 }
 
 extension InsightViewModel {
-    // overallTask 완료 후 UI 갱신
     private func updateOverallUI() async {
         await TaskResultHandler.applyResult(
             of: overallTask,
@@ -145,7 +138,6 @@ extension InsightViewModel {
         )
     }
     
-    // communityTask 완료 후 UI 갱신
     private func updateCommunityUI() async {
         await TaskResultHandler.applyResult(
             of: communityTask,

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
@@ -42,6 +42,10 @@ final class InsightViewModel: ObservableObject {
             try await alanAPIService.fetchTodayInsight()
         }
         
+        communityTask = Task {
+            try await fetchCommunityFlow()
+        }
+        
         communityTask = Task { [weak self] in
             try await withTaskCancellationHandler(
                 operation: {
@@ -56,9 +60,9 @@ final class InsightViewModel: ObservableObject {
         }
         
         Task {
-            await awaitOverallAndUpdateUI()
+            await updateOverallUI()
             try? await Task.sleep(for: .milliseconds(350))
-            await awaitCommunityAndUpdateUI()
+            await updateCommunityUI()
         }
     }
     
@@ -66,57 +70,7 @@ final class InsightViewModel: ObservableObject {
     private func fetchCommunityFlow() async throws -> InsightDTO {
         let communityData = try await redditAPIService.fetchData()
         
-        return try await alanAPIService.fetchCommunityInsight(from: makeCommunitySummary(from: communityData))
-    }
-    
-    // overallTask 완료 후 UI 갱신
-    func awaitOverallAndUpdateUI() async {
-        do {
-            let data = try await overallTask?.value
-            if let data {
-                let insight = Insight(
-                    sentiment: Sentiment(rawValue: data.todaysSentiment) ?? .neutral,
-                    summary: data.summary
-                )
-                await MainActor.run { overall = .success(insight) }
-            }
-        } catch {
-            if error.isTaskCancellation {
-                await MainActor.run { overall = .cancel(.taskCancelled) }
-                return
-            }
-            if let ne = error as? NetworkError {
-                print(ne.log())
-                await MainActor.run { overall = .failure(ne) }
-            } else {
-                print(error)
-            }
-        }
-    }
-    
-    // communityTask 완료 후 UI 갱신
-    func awaitCommunityAndUpdateUI() async {
-        do {
-            let data = try await communityTask?.value
-            if let data {
-                let insight = Insight(
-                    sentiment: Sentiment(rawValue: data.todaysSentiment) ?? .neutral,
-                    summary: data.summary
-                )
-                await MainActor.run { community = .success(insight) }
-            }
-        } catch {
-            if error.isTaskCancellation {
-                await MainActor.run { community = .cancel(.taskCancelled) }
-                return
-            }
-            if let ne = error as? NetworkError {
-                print(ne.log())
-                await MainActor.run { community = .failure(ne) }
-            } else {
-                print(error)
-            }
-        }
+        return try await alanAPIService.fetchCommunityInsight(from: communityData.communitySummary)
     }
     
     // overall만 다시 시도
@@ -130,8 +84,8 @@ final class InsightViewModel: ObservableObject {
         
         overallTask = Task { try await alanAPIService.fetchTodayInsight() }
         
-        Task { [weak self] in
-            await self?.awaitOverallAndUpdateUI()
+        Task {
+            await updateOverallUI()
         }
     }
     
@@ -146,13 +100,20 @@ final class InsightViewModel: ObservableObject {
         
         communityTask = Task { try await fetchCommunityFlow() }
         
-        Task { [weak self] in
-            await self?.awaitCommunityAndUpdateUI()
+        Task {
+            await updateCommunityUI()
         }
     }
     
-    func cancelOverall() { overallTask?.cancel() }
-    func cancelCommunity() { communityTask?.cancel() }
+    func cancelOverall() {
+        overallTask?.cancel()
+        
+        // 취소 UI 업데이트 -> 그럼 취소 확인은?
+    }
+    
+    func cancelCommunity() {
+        communityTask?.cancel()
+    }
     
     // TODO: 탭 전환시 자동 cancel
     // 전체 Task 취소
@@ -168,7 +129,39 @@ final class InsightViewModel: ObservableObject {
 }
 
 extension InsightViewModel {
+    // overallTask 완료 후 UI 갱신
+    private func updateOverallUI() async {
+        await TaskResultHandler.applyResult(
+            of: overallTask,
+            using: { data in
+                Insight(
+                    sentiment: Sentiment(rawValue: data.todaysSentiment) ?? .neutral,
+                    summary: data.summary
+                )
+            },
+            update: { [weak self] state in
+                self?.overall = state
             }
+        )
+    }
+    
+    // communityTask 완료 후 UI 갱신
+    private func updateCommunityUI() async {
+        await TaskResultHandler.applyResult(
+            of: communityTask,
+            using: { data in
+                Insight(
+                    sentiment: Sentiment(rawValue: data.todaysSentiment) ?? .neutral,
+                    summary: data.summary
+                )
+            },
+            update: { [weak self] state in
+                self?.community = state
+            }
+        )
+    }
+}
+
 extension InsightViewModel {
     var sectionDataSource: [ReportSectionData<Insight>] {
         [


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- close #319 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 지난 멘토링 당시 아래와 같이 피드백을 받았습니다
    > `withTaskCancellationHandler`를 사용해서 취소를 확인하고 UI를 업데이트 하는 것이 코드의 흐름을 보는 데에 어려움 + `withTaskCancellationHandler`를 통일성있게 상위 task에서도 사용해야 어색하지 않음 -> 취소 버튼을 누를 때 호출되는 cancel 함수에서 취소 UI를 업데이트하는 것 추천
    - 하지만 task.cancel 후에 기존 코드보다 더 간단하게 해당 task의 취소를 확인하고 UI를 업데이트 할 수 있는 방법이 생각나지 않아 기존 코드를 유지했습니다. (추후 좋은 방법이 생각나면 추가로 리팩토링 예정입니다.)
- ViewModel에 있던 네트워크 응답 데이터의 가공 로직을 각 DTO로 이동했습니다.
- View에서 작성하고있던 icon image 이름, section title를 ViewModel의 데이터 소스로 이동하여 View 코드를 더 간단하게 리팩토링 했습니다.
- 코드 중복을 줄이기 위해 네트워크 결과를 UI에 반영하는 `TaskResultHandler.applyResult`를 구현했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- `TaskResultHandler.applyResult`의 이름, 파라미터 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- `TaskResultHandler` 위치가 `Core/Util/`인데 괜찮을까요?
- 한번 짠 코드를 리팩토링하려니 코드가 발전한다기 보다는 자꾸 제자리에 머물러있다는 생각이 들어 슬픕니다...