### PR TITLE
앱 전반에서 stroke 잘리는 부분 개선

### DIFF
--- a/AIProject/AIProject/Features/Base/CircleDeleteButton.swift
+++ b/AIProject/AIProject/Features/Base/CircleDeleteButton.swift
@@ -28,7 +28,7 @@ struct CircleDeleteButton: View {
                 }
                 .overlay {
                     Circle()
-                        .stroke(Gradient.aiCoGradientStyle(.default), lineWidth: 0.5)
+                        .strokeBorder(Gradient.aiCoGradientStyle(.default), lineWidth: 0.5)
                 }
         }
     }

--- a/AIProject/AIProject/Features/Base/CircleIconView.swift
+++ b/AIProject/AIProject/Features/Base/CircleIconView.swift
@@ -26,7 +26,7 @@ struct CircleIconView: View {
         .frame(width: 36, height: 36)
         .background(.aiCoBackgroundAccent)
         .clipShape(Circle())
-        .overlay(Circle().stroke(.accentGradient, lineWidth: 0.5))
+        .overlay(Circle().strokeBorder(.accentGradient, lineWidth: 0.5))
     }
 }
 

--- a/AIProject/AIProject/Features/Base/DefaultProgressView.swift
+++ b/AIProject/AIProject/Features/Base/DefaultProgressView.swift
@@ -64,13 +64,13 @@ struct DefaultProgressView: View {
                         .font(.system(size: 35))
                         .foregroundStyle(.aiCoNeutral)
                         .padding(8)
-                        .background(.aiCoBackground)
+                        .background(.aiCoBackgroundWhite)
                 case .cancel:
                     Image(systemName: "exclamationmark.octagon")
                         .font(.system(size: 35))
                         .foregroundStyle(.aiCoNeutral)
                         .padding(8)
-                        .background(.aiCoBackground)
+                        .background(.aiCoBackgroundWhite)
                 }
             }
             .clipShape(.circle)

--- a/AIProject/AIProject/Features/Base/DefaultProgressView.swift
+++ b/AIProject/AIProject/Features/Base/DefaultProgressView.swift
@@ -76,7 +76,7 @@ struct DefaultProgressView: View {
             .clipShape(.circle)
             .overlay {
                 Circle()
-                    .stroke(status == .loading ? .accentGradient : .defaultGradient, lineWidth: 0.5)
+                    .strokeBorder(status == .loading ? .accentGradient : .defaultGradient, lineWidth: 0.5)
             }
             .padding(15)
             .frame(width: 80, height: 80)

--- a/AIProject/AIProject/Features/Base/ReportSectionView.swift
+++ b/AIProject/AIProject/Features/Base/ReportSectionView.swift
@@ -101,7 +101,7 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         .overlay(
             RoundedRectangle(cornerRadius: cornerRadius)
-                .stroke(.defaultGradient, lineWidth: 0.5)
+                .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
     }
 }

--- a/AIProject/AIProject/Features/Base/RoundedButton.swift
+++ b/AIProject/AIProject/Features/Base/RoundedButton.swift
@@ -42,7 +42,7 @@ struct RoundedButton: View {
             )
             .overlay {
                 Capsule()
-                    .stroke(.defaultGradient, lineWidth: 0.5)
+                    .strokeBorder(.defaultGradient, lineWidth: 0.5)
             }
         }
     }

--- a/AIProject/AIProject/Features/Base/RoundedRectangleButton.swift
+++ b/AIProject/AIProject/Features/Base/RoundedRectangleButton.swift
@@ -47,7 +47,7 @@ struct RoundedRectangleButton: View {
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius)
-                    .stroke(isActive ? .accentGradient : .defaultGradient, lineWidth: 0.5)
+                    .strokeBorder(isActive ? .accentGradient : .defaultGradient, lineWidth: 0.5)
             )
         }
     }

--- a/AIProject/AIProject/Features/Base/RoundedRectangleFillButton.swift
+++ b/AIProject/AIProject/Features/Base/RoundedRectangleFillButton.swift
@@ -85,7 +85,7 @@ struct RoundedRectangleFillButtonView: View {
         .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         .overlay(
             RoundedRectangle(cornerRadius: cornerRadius)
-                .stroke(!isHighlighted ? .defaultGradient : .accentGradient, lineWidth: 0.5)
+                .strokeBorder(!isHighlighted ? .defaultGradient : .accentGradient, lineWidth: 0.5)
         )
     }
 }

--- a/AIProject/AIProject/Features/Base/SegmentedControlView.swift
+++ b/AIProject/AIProject/Features/Base/SegmentedControlView.swift
@@ -57,7 +57,7 @@ struct SegmentedControlView: View {
         .background(.aiCoBackgroundAccent)
         .frame(width: width)
         .clipShape(Capsule())
-        .overlay { Capsule().stroke(.defaultGradient, lineWidth: 0.5) }
+        .overlay { Capsule().strokeBorder(.defaultGradient, lineWidth: 0.5) }
     }
 }
 

--- a/AIProject/AIProject/Features/ChatBot/View/BotMessageView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/BotMessageView.swift
@@ -23,7 +23,7 @@ struct BotMessageView: View {
                     .padding(8)
                     .overlay {
                         Circle()
-                            .stroke(.accentGradient, lineWidth: 0.5)
+                            .strokeBorder(.accentGradient, lineWidth: 0.5)
                     }
                     .background {
                         Circle()
@@ -48,12 +48,12 @@ struct BotMessageView: View {
             .padding(.vertical, 15)
             .padding(.horizontal, 18)
             .background {
-                RoundedCorner(radius: 16, corners: [.topRight, .bottomLeft, .bottomRight])
+                UnevenRoundedRectangle(bottomLeadingRadius: 16, bottomTrailingRadius: 16, topTrailingRadius: 16)
                     .fill(.aiCoBackgroundAccent)
             }
             .overlay {
-                RoundedCorner(radius: 16, corners: [.topRight, .bottomLeft, .bottomRight])
-                    .stroke(.accentGradient, lineWidth: 0.5)
+                UnevenRoundedRectangle(bottomLeadingRadius: 16, bottomTrailingRadius: 16, topTrailingRadius: 16)
+                    .strokeBorder(.defaultGradient, lineWidth: 0.5)
             }
             .frame(maxWidth: 300, alignment: .leading)
 

--- a/AIProject/AIProject/Features/ChatBot/View/ChatInputView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/ChatInputView.swift
@@ -36,7 +36,7 @@ struct ChatInputView: View {
             }
             .overlay {
                 Circle()
-                    .stroke(viewModel.isEditable ? .accentGradient : .defaultGradient, lineWidth: 0.5)
+                    .strokeBorder(viewModel.isEditable ? .accentGradient : .defaultGradient, lineWidth: 0.5)
             }
             .disabled(!viewModel.isEditable)
         }
@@ -48,7 +48,7 @@ struct ChatInputView: View {
         .padding(.vertical, 10)
         .overlay {
             RoundedRectangle(cornerRadius: 30)
-                .stroke(.defaultGradient, lineWidth: 0.5)
+                .strokeBorder(.defaultGradient, lineWidth: 0.5)
         }
         .padding(.horizontal)
         .padding(.bottom, 10)

--- a/AIProject/AIProject/Features/ChatBot/View/UserMessageView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/UserMessageView.swift
@@ -23,12 +23,12 @@ struct UserMessageView: View {
                 .padding(.vertical, 15)
                 .padding(.horizontal, 18)
                 .background {
-                    RoundedCorner(radius: 16, corners: [.topLeft, .bottomLeft, .bottomRight])
+                    UnevenRoundedRectangle(topLeadingRadius: 16, bottomLeadingRadius: 16, bottomTrailingRadius: 16)
                         .fill(Color.aiCoBackgroundWhite)
                 }
                 .overlay {
-                    RoundedCorner(radius: 16, corners: [.topLeft, .bottomLeft, .bottomRight])
-                        .stroke(Gradient.aiCoGradientStyle(.default), lineWidth: 0.5)
+                    UnevenRoundedRectangle(topLeadingRadius: 16, bottomLeadingRadius: 16, bottomTrailingRadius: 16)
+                        .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 }
                 .frame(maxWidth: 300, alignment: .trailing)
         }

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -66,7 +66,7 @@ struct ChartView: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(.defaultGradient, lineWidth: 0.5)
+                .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
         .onAppear {
             viewModel.checkBookmark()

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportNewsSectionView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportNewsSectionView.swift
@@ -78,7 +78,7 @@ struct ReportNewsSectionView: View {
         .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
         .overlay(
             RoundedRectangle(cornerRadius: Self.cornerRadius)
-                .stroke(.defaultGradient, lineWidth: 0.5)
+                .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/View/FearGreedView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/FearGreedView.swift
@@ -45,7 +45,7 @@ struct FearGreedView: View {
         .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
         .overlay(
             RoundedRectangle(cornerRadius: Self.cornerRadius)
-                .stroke(.defaultGradient, lineWidth: 0.5)
+                .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/View/RecomendationPlaceholderCardView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/RecomendationPlaceholderCardView.swift
@@ -40,7 +40,7 @@ struct RecomendationPlaceholderCardView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 24))
                         .overlay {
                             RoundedRectangle(cornerRadius: 24)
-                                .stroke(.defaultGradient, lineWidth: 0.5)
+                                .strokeBorder(.defaultGradient, lineWidth: 0.5)
                         }
                     }
                     .frame(maxWidth: geoProxy.size.width - (CardConst.cardInnerPadding * 2))
@@ -61,7 +61,7 @@ struct RecomendationPlaceholderCardView: View {
                 .frame(height: CardConst.cardHeight)
                 .clipShape(RoundedRectangle(cornerRadius: 20))
                 .overlay(
-                    hSizeClass == .regular ? RoundedRectangle(cornerRadius: 20).stroke(.defaultGradient, lineWidth: 0.5) : nil)
+                    hSizeClass == .regular ? RoundedRectangle(cornerRadius: 20).strokeBorder(.defaultGradient, lineWidth: 0.5) : nil)
             }
             .frame(width: geoProxy.size.width)
         }

--- a/AIProject/AIProject/Features/Dashboard/View/RecommendCardView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/RecommendCardView.swift
@@ -90,7 +90,7 @@ struct RecommendCardView: View {
         .clipShape(RoundedRectangle(cornerRadius: 24))
         .overlay {
             RoundedRectangle(cornerRadius: 24)
-                .stroke(.defaultGradient, lineWidth: 0.5)
+                .strokeBorder(.defaultGradient, lineWidth: 0.5)
         }
     }
 }

--- a/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
+++ b/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
@@ -35,10 +35,13 @@ struct CoinListView: View {
             CoinListHeaderView(sortCategory: $store.sortCategory, rateSortOrder: $store.rateSortOrder, volumeSortOrder: $store.volumeSortOrder)
             makeCoinContents()
         }
-        .background {
+        .overlay {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .strokeBorder(.defaultGradient, lineWidth: 0.5)
-                .fill(Color.aiCoBackground)
+        }
+        .background {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.aiCoBackground)
         }
         .clipShape(.rect(cornerRadius: 16))
         .onChange(of: scenePhase, { _, newValue in

--- a/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
+++ b/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
@@ -95,7 +95,10 @@ struct CoinListView: View {
                         .listRowSeparator(.hidden)
                         .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
                         .listRowBackground(selectedCoinID == id && isIpad ? Color.aiCoBackgroundAccent : Color.clear)
-                        .background(Rectangle().strokeBorder(.defaultGradient, lineWidth: 0.5))
+                        .overlay(
+                            LinearGradient.defaultGradient.frame(height: 0.5),
+                            alignment: .bottom
+                        )
                         .onTapGesture {
                             store.addRecord(id)
                             selectedCoinID = id

--- a/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
+++ b/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
@@ -37,7 +37,7 @@ struct CoinListView: View {
         }
         .background {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(.defaultGradient, lineWidth: 0.5)
+                .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 .fill(Color.aiCoBackground)
         }
         .clipShape(.rect(cornerRadius: 16))
@@ -92,7 +92,7 @@ struct CoinListView: View {
                         .listRowSeparator(.hidden)
                         .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
                         .listRowBackground(selectedCoinID == id && isIpad ? Color.aiCoBackgroundAccent : Color.clear)
-                        .background(Rectangle().stroke(.defaultGradient, lineWidth: 0.5))
+                        .background(Rectangle().strokeBorder(.defaultGradient, lineWidth: 0.5))
                         .onTapGesture {
                             store.addRecord(id)
                             selectedCoinID = id

--- a/AIProject/AIProject/Features/Market/SubView/CoinListHeaderView.swift
+++ b/AIProject/AIProject/Features/Market/SubView/CoinListHeaderView.swift
@@ -40,6 +40,7 @@ struct CoinListHeaderView: View {
         .listRowSeparator(.hidden)
         .padding(.horizontal)
         .padding(.vertical, 8)
+        .background(.ultraThinMaterial)
 //        .background {
 //                UnevenRoundedRectangle(topLeadingRadius: 16, bottomLeadingRadius: 0, bottomTrailingRadius: 0, topTrailingRadius: 16, style: .continuous)
 //                .strokeBorder(.defaultGradient, lineWidth: 0.5)

--- a/AIProject/AIProject/Features/Market/SubView/CoinListHeaderView.swift
+++ b/AIProject/AIProject/Features/Market/SubView/CoinListHeaderView.swift
@@ -42,7 +42,7 @@ struct CoinListHeaderView: View {
         .padding(.vertical, 8)
 //        .background {
 //                UnevenRoundedRectangle(topLeadingRadius: 16, bottomLeadingRadius: 0, bottomTrailingRadius: 0, topTrailingRadius: 16, style: .continuous)
-//                .stroke(.defaultGradient, lineWidth: 0.5)
+//                .strokeBorder(.defaultGradient, lineWidth: 0.5)
 //        }
     }
 }

--- a/AIProject/AIProject/Features/Market/SubView/HeaderToggleButton.swift
+++ b/AIProject/AIProject/Features/Market/SubView/HeaderToggleButton.swift
@@ -39,7 +39,7 @@ struct HeaderToggleButton: View {
                 )
                 .overlay {
                     Capsule()
-                        .stroke(.defaultGradient, lineWidth: 0.5)
+                        .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 }
             }
             .fontWeight(sortOrder != .none ? .bold : .regular)

--- a/AIProject/AIProject/Features/Market/SubView/RecentCoinSectionView.swift
+++ b/AIProject/AIProject/Features/Market/SubView/RecentCoinSectionView.swift
@@ -32,7 +32,7 @@ struct RecentCoinSectionView: View {
                     .padding(.vertical, 8)
                     .padding(.horizontal, 12)
                     .background {
-                        Capsule().stroke(.defaultGradient, lineWidth: 0.5)
+                        Capsule().strokeBorder(.defaultGradient, lineWidth: 0.5)
                     }
                     .onTapGesture {
                         tapAction(coin.id)

--- a/AIProject/AIProject/Features/MyPage/View/BookmarkBulkInsert/ContentSection.swift
+++ b/AIProject/AIProject/Features/MyPage/View/BookmarkBulkInsert/ContentSection.swift
@@ -31,7 +31,7 @@ struct ContentSection: View {
                             .clipShape(.circle)
                             .overlay {
                                 Circle()
-                                    .stroke(.defaultGradient, lineWidth: 0.5)
+                                    .strokeBorder(.defaultGradient, lineWidth: 0.5)
                             }
                             .padding(.bottom, 16)
                         

--- a/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
@@ -130,7 +130,7 @@ struct BookmarkView: View {
                             .fill(Color.aiCoBackgroundAccent)
                             .overlay(
                                 RoundedRectangle(cornerRadius: 12)
-                                    .stroke(.accent, lineWidth: 0.5)
+                                    .strokeBorder(.accent, lineWidth: 0.5)
                             )
                     )
                     .cornerRadius(20)

--- a/AIProject/AIProject/Features/MyPage/View/CoinListSectionView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/CoinListSectionView.swift
@@ -52,7 +52,7 @@ struct CoinListSectionView: View {
                 .fill(Color.aiCoBackground)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(.defaultGradient, lineWidth: 0.5)
+                        .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 )
         )
         .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/AIProject/AIProject/Features/MyPage/View/Main/MyPageView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/Main/MyPageView.swift
@@ -86,7 +86,7 @@ struct MyPageView: View {
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 20)
-                        .stroke(.defaultGradient, lineWidth: 0.5)
+                        .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 )
             }
             .padding(.horizontal, 16)

--- a/AIProject/AIProject/Features/MyPage/View/Theme/ThemeRow.swift
+++ b/AIProject/AIProject/Features/MyPage/View/Theme/ThemeRow.swift
@@ -46,7 +46,7 @@ struct ThemeRow: View {
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius)
-                    .stroke(!isSelected ? .defaultGradient : .accentGradient, lineWidth: 0.5)
+                    .strokeBorder(!isSelected ? .defaultGradient : .accentGradient, lineWidth: 0.5)
             )
         }
     }

--- a/AIProject/AIProject/Features/Search/SearchBarView.swift
+++ b/AIProject/AIProject/Features/Search/SearchBarView.swift
@@ -45,7 +45,7 @@ struct SearchBarView: View {
             }
             .overlay {
                 RoundedRectangle(cornerRadius: 15)
-                    .stroke(showCancel ? .accentGradient : .defaultGradient, lineWidth: 0.5)
+                    .strokeBorder(showCancel ? .accentGradient : .defaultGradient, lineWidth: 0.5)
             }
             .animation(.snappy(duration: 0.1), value: showCancel)
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- stroke → strokeBorder 변경
- 코인 리스트 row의 상하 stroke가 겹쳐져 진하게 보여서 stroke 변경 : 4면 테두리 → 하단 테두리

### 스크린샷 (선택)

<img width="600" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2025-08-26 at 13 41 08" src="https://github.com/user-attachments/assets/d06f20ea-41ac-481b-b231-2274d2dee60b" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

지난 번에 리스트 헤더랑 바디랑 구분이 됐으면 좋겠다고 하셨던 것 같아서, 손 댄 김에 리스트 헤더에 배경색을 넣어봤어요!
아직 적용은 안했고 위 이미지처럼 변경해도 괜찮을지 의견 알려주세요~