### PR TITLE
InsightDTO -> Insight 변환 로직을 Service로 이동

### DIFF
--- a/AIProject/AIProject/Core/Util/TaskResultHandler.swift
+++ b/AIProject/AIProject/Core/Util/TaskResultHandler.swift
@@ -44,3 +44,18 @@ enum TaskResultHandler {
         }
     }
 }
+
+extension TaskResultHandler {
+    static func apply<Output>(
+        of task: Task<Output, Error>?,
+        update: @escaping (FetchState<Output>) -> Void,
+        sideEffect: ((Output) -> Void)? = nil
+    ) async {
+        await apply(
+            of: task,
+            using: { $0 },
+            update: update,
+            sideEffect: sideEffect
+        )
+    }
+}

--- a/AIProject/AIProject/Data/API/Alan/AlanAPIService.swift
+++ b/AIProject/AIProject/Data/API/Alan/AlanAPIService.swift
@@ -261,7 +261,7 @@ extension AlanAPIService {
     /// 캐시가 있다면 캐시된 데이터를 먼저 반환하고, 없으면 새로 요청 후 캐싱합니다.
     /// - Parameter coin: 대상 코인
     /// - Returns: 디코딩된 DTO
-    func fetchTodayInsight(now: Date = .now) async throws -> InsightDTO {
+    func fetchTodayInsight(now: Date = .now) async throws -> Insight {
         let insightTTL: TimeInterval = 60 * 60
         
         if !cacheBriefTodayTimestamp.isEmpty,
@@ -272,7 +272,8 @@ extension AlanAPIService {
             if let cachedResponse = URLCache.shared.cachedResponse(for: request),
                 now.timeIntervalSince(savedDate) < insightTTL {
                 do {
-                    return try JSONDecoder().decode(InsightDTO.self, from: cachedResponse.data)
+                    let dto: InsightDTO = try JSONDecoder().decode(InsightDTO.self, from: cachedResponse.data)
+                    return dto.toDomain()
                 } catch let decodingError as DecodingError {
                     throw NetworkError.decodingError(decodingError)
                 }
@@ -308,7 +309,7 @@ extension AlanAPIService {
 
         cacheBriefTodayTimestamp = now.dateAndTime
         
-        return dto
+        return dto.toDomain()
     }
     
     /// 주어진 코인에 대해 커뮤니티 기반 인사이트 데이터를 가져옵니다.
@@ -316,7 +317,7 @@ extension AlanAPIService {
     /// 캐시가 있다면 캐시된 데이터를 먼저 반환하고, 없으면 새로 요청 후 캐싱합니다.
     /// - Parameter coin: 대상 코인
     /// - Returns: 디코딩된 DTO
-    func fetchCommunityInsight(from post: String, now: Date = .now) async throws -> InsightDTO {
+    func fetchCommunityInsight(from post: String, now: Date = .now) async throws -> Insight {
         let insightTTL: TimeInterval = 60 * 60
         
         if !cacheBriefCommunityTimestamp.isEmpty,
@@ -327,7 +328,8 @@ extension AlanAPIService {
             if let cachedResponse = URLCache.shared.cachedResponse(for: request),
                 now.timeIntervalSince(savedDate) < insightTTL {
                 do {
-                    return try JSONDecoder().decode(InsightDTO.self, from: cachedResponse.data)
+                    let dto: InsightDTO = try JSONDecoder().decode(InsightDTO.self, from: cachedResponse.data)
+                    return dto.toDomain()
                 } catch let decodingError as DecodingError {
                     throw NetworkError.decodingError(decodingError)
                 }
@@ -363,7 +365,7 @@ extension AlanAPIService {
 
         cacheBriefCommunityTimestamp = Date.dateAndTimeFormatter.string(from: now)
         
-        return dto
+        return dto.toDomain()
     }
     
     /// 북마크된 코인 전체에 대한 투자 브리핑과 전략 제안을 JSON 형식으로 가져옵니다.

--- a/AIProject/AIProject/Data/API/Alan/DTO/Content/InsightDTO.swift
+++ b/AIProject/AIProject/Data/API/Alan/DTO/Content/InsightDTO.swift
@@ -14,3 +14,12 @@ struct InsightDTO: Codable {
     /// 평가 이유
     let summary: String
 }
+
+extension InsightDTO {
+    func toDomain() -> Insight {
+        Insight(
+            sentiment: Sentiment(rawValue: todaysSentiment) ?? .neutral,
+            summary: summary
+        )
+    }
+}

--- a/AIProject/AIProject/Features/Base/ReportSectionView.swift
+++ b/AIProject/AIProject/Features/Base/ReportSectionView.swift
@@ -46,7 +46,7 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 16) {
             // Header
             HStack {
                 Image(systemName: data.icon)

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -38,18 +38,16 @@ struct AIBriefingView: View {
                 if isPadLayout {
                     HStack(spacing: 16) {
                         briefingView
-                            .frame(height: 280)
                     }
                 } else {
                     briefingView
-                        .frame(height: 260)
                 }
                 
                 FearGreedView()
-                    .padding(.bottom, 30)
             }
         }
         .padding(.horizontal, 16)
+        .padding(.bottom, 30)
     }
     
     @ViewBuilder
@@ -64,10 +62,12 @@ struct AIBriefingView: View {
                 },
                 content: { Text($0.summary.byCharWrapping) }
             )
+            .frame(height: 280)
         }
     }
 }
 
 #Preview {
     AIBriefingView()
+        .environmentObject(ThemeManager())
 }

--- a/AIProject/AIProject/Features/Dashboard/View/FearGreedView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/FearGreedView.swift
@@ -21,7 +21,7 @@ struct FearGreedView: View {
     }
     
     var body: some View {
-        HStack(alignment: .top, spacing: 16) {
+        HStack(alignment: .center, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
                 Text("공포 & 탐욕 지수")
                     .font(.system(size: 19, weight: .bold))

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/InsightViewModel.swift
@@ -25,8 +25,8 @@ final class InsightViewModel: ObservableObject {
     private let alanAPIService = AlanAPIService()
     private let redditAPIService = RedditAPIService()
     
-    private var overallTask: Task<InsightDTO, Error>?
-    private var communityTask: Task<InsightDTO, Error>?
+    private var overallTask: Task<Insight, Error>?
+    private var communityTask: Task<Insight, Error>?
     
     init() {
         load()
@@ -66,7 +66,7 @@ final class InsightViewModel: ObservableObject {
     }
     
     // Reddit 데이터를 가져와 요약 후 인사이트 생성
-    private func fetchCommunityFlow() async throws -> InsightDTO {
+    private func fetchCommunityFlow() async throws -> Insight {
         let communityData = try await redditAPIService.fetchData()
         
         return try await alanAPIService.fetchCommunityInsight(from: communityData.communitySummary)
@@ -124,12 +124,6 @@ extension InsightViewModel {
     private func updateOverallUI() async {
         await TaskResultHandler.apply(
             of: overallTask,
-            using: { data in
-                Insight(
-                    sentiment: Sentiment(rawValue: data.todaysSentiment) ?? .neutral,
-                    summary: data.summary
-                )
-            },
             update: { [weak self] state in
                 self?.overall = state
             }
@@ -139,12 +133,6 @@ extension InsightViewModel {
     private func updateCommunityUI() async {
         await TaskResultHandler.apply(
             of: communityTask,
-            using: { data in
-                Insight(
-                    sentiment: Sentiment(rawValue: data.todaysSentiment) ?? .neutral,
-                    summary: data.summary
-                )
-            },
             update: { [weak self] state in
                 self?.community = state
             }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- DTO를 도메인 모델로 변환하는 로직이 원래 VM에 있었는데 service로 이동했습니다. 

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- 없습니다!