### PR TITLE
Fix/socket reconnect issue kh

### DIFF
--- a/AIProject/AIProject/Features/Main/MainTabView.swift
+++ b/AIProject/AIProject/Features/Main/MainTabView.swift
@@ -7,32 +7,38 @@
 
 import SwiftUI
 
+
 struct MainTabView: View {
+    @State private var router = TabRouter()
+    private let tickerService: RealTimeTickerProvider = UpbitTickerService()
+    private let upbitService: UpBitAPIService = UpBitAPIService()
     
     var body: some View {
-        TabView {
+        TabView(selection: $router.selected) {
+            ForEach(TabFeature.allCases) { tab in
+                makeTab(tab)
+                    .tabItem {
+                        Label(tab.rawValue, systemImage: tab.icon)
+                    }
+                    .tag(tab)
+            }
+        }
+        .environment(router)
+    }
+    
+    @ViewBuilder func makeTab(_ tab: TabFeature) -> some View {
+        switch tab {
+        case .dashboard:
             DashboardView()
-                .tabItem {
-                    Label("대시보드", systemImage: "square.grid.2x2")
-                }
-            
+        case .market:
             MarketView(
-                coinService: UpBitAPIService(),
-                tickerService: UpbitTickerService()
+                coinService: upbitService,
+                tickerService: tickerService
             )
-                .tabItem {
-                    Label("마켓", systemImage: "bitcoinsign.bank.building")
-                }
-            
+        case .chatbot:
             ChatBotView()
-                .tabItem {
-                    Label("챗봇", systemImage: "bubble.left.and.text.bubble.right")
-                }
-            
+        case .myPage:
             MyPageView()
-                .tabItem {
-                    Label("마이페이지", systemImage: "person.crop.circle")
-                }
         }
     }
 }

--- a/AIProject/AIProject/Features/Main/MainTabView.swift
+++ b/AIProject/AIProject/Features/Main/MainTabView.swift
@@ -7,11 +7,10 @@
 
 import SwiftUI
 
-
 struct MainTabView: View {
     @State private var router = TabRouter()
-    private let tickerService: RealTimeTickerProvider = UpbitTickerService()
-    private let upbitService: UpBitAPIService = UpBitAPIService()
+    @State private var tickerService: RealTimeTickerProvider = UpbitTickerService()
+    @State private var upbitService: UpBitAPIService = UpBitAPIService()
     
     var body: some View {
         TabView(selection: $router.selected) {

--- a/AIProject/AIProject/Features/Main/TabFeature.swift
+++ b/AIProject/AIProject/Features/Main/TabFeature.swift
@@ -1,0 +1,32 @@
+//
+//  TabFeature.swift
+//  AIProject
+//
+//  Created by kangho lee on 8/26/25.
+//
+
+import SwiftUI
+
+enum TabFeature: String, Hashable, CaseIterable, Identifiable {
+    case dashboard = "대시보드"
+    case market = "마켓"
+    case chatbot = "챗봇"
+    case myPage = "마이페이지"
+    
+    var icon: String {
+        switch self {
+        case .dashboard:
+            return "square.grid.2x2"
+        case .market:
+            return "bitcoinsign.bank.building"
+        case .chatbot:
+            return "bubble.left.and.text.bubble.right"
+        case .myPage:
+            return "person.crop.circle"
+        }
+    }
+    
+    var id: String {
+        return rawValue
+    }
+}

--- a/AIProject/AIProject/Features/Main/TabRouter.swift
+++ b/AIProject/AIProject/Features/Main/TabRouter.swift
@@ -1,0 +1,13 @@
+//
+//  TabRouter.swift
+//  AIProject
+//
+//  Created by kangho lee on 8/26/25.
+//
+
+import Foundation
+
+@Observable
+final class TabRouter {
+    var selected: TabFeature = .dashboard
+}

--- a/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
+++ b/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
@@ -12,9 +12,10 @@ struct CoinListView: View {
     @Bindable var store: MarketStore
     
     @State private var visibleCoins: Set<CoinID> = []
-    @State private var isOnList: Bool = true
+    @State private var isActive: Bool = false
     
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(TabRouter.self) private var router
     
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \BookmarkEntity.timestamp, ascending: false)],
@@ -24,6 +25,7 @@ struct CoinListView: View {
     
     @Binding private var selectedCoinID: CoinID?
     @Binding private var searchText: String
+    
     init(store: MarketStore, selectedCoinID: Binding<CoinID?>, searchText: Binding<String>) {
         self.store = store
         _selectedCoinID = selectedCoinID
@@ -46,7 +48,7 @@ struct CoinListView: View {
         .clipShape(.rect(cornerRadius: 16))
         .onChange(of: scenePhase, { _, newValue in
             Task {
-                guard isOnList else { return }
+                guard router.selected == .market && isActive else { return }
                 await handleConnection(by: newValue)
             }
         })
@@ -60,15 +62,14 @@ struct CoinListView: View {
                 await store.update(newValue)
             }
         }
-        .onAppear {
-            Task {
-                isOnList = true
-                await store.connect()
-            }
+        .task {
+            isActive = true
+            guard router.selected == .market else { return }
+            await store.connect()
         }
         .onDisappear {
             Task {
-                isOnList = false
+                isActive = false
                 await store.disconnect()
             }
         }
@@ -77,16 +78,12 @@ struct CoinListView: View {
     @ViewBuilder func makeCoinContents() -> some View {
         if store.filter == .bookmark, bookmarks.isEmpty {
             VStack {
-                Spacer()
-                
                 Text("북마크한 코인이 없습니다 🥵")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, minHeight: 300)
                     .multilineTextAlignment(.center)
                     .padding()
-                
-                Spacer()
             }
         } else {
             List(store.sortedCoinIDs, id: \.self, selection: $selectedCoinID) { id in

--- a/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
+++ b/AIProject/AIProject/Features/Market/CoinList/CoinListView.swift
@@ -85,6 +85,7 @@ struct CoinListView: View {
                     .multilineTextAlignment(.center)
                     .padding()
             }
+            .frame(maxHeight: .infinity)
         } else {
             List(store.sortedCoinIDs, id: \.self, selection: $selectedCoinID) { id in
                 if let meta = store.coinMeta[id], let ticker = store.ticker(for: id) {

--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -40,6 +40,7 @@ struct MarketView: View {
                     RecentCoinSectionView(coins: records.compactMap { store.coinMeta[$0.query] }, deleteAction: { coin in
                         store.deleteRecord(coin.id)
                     }) { selectedCoinID = $0 }
+                        .padding(.bottom, 16)
                 }
 
                 VStack(spacing: 16) {
@@ -57,7 +58,8 @@ struct MarketView: View {
 
                     CoinListView(store: store, selectedCoinID: $selectedCoinID, searchText: $searchText)
                 }
-                .padding(16)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 16)
                 .refreshable {
                     Task {
                         await store.refresh()
@@ -90,6 +92,9 @@ struct MarketView: View {
 #Preview {
     MarketView(
         coinService: UpBitAPIService(),
-        tickerService: UpbitTickerService()
+        tickerService: UpbitTickerService(client: 
+                                          ReconnectableWebSocketClient {
+                                          BaseWebSocketClient(url: URL(string: "wss://api.upbit.com/websocket/v1")!)
+                                          })
     )
 }

--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -29,18 +29,17 @@ struct MarketView: View {
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility, preferredCompactColumn: .constant(.sidebar)) {
-            Group {
-                VStack(spacing: 16) {
-                    HeaderView(heading: "마켓")
-
-                    SearchBarView(searchText: $searchText)
-                        .padding(.horizontal, 16)
-
-                    if !records.isEmpty {
-                        RecentCoinSectionView(coins: records.compactMap { store.coinMeta[$0.query] }, deleteAction: { coin in
-                            store.deleteRecord(coin.id)
-                        }) { selectedCoinID = $0 }
-                    }
+            VStack(spacing: 0) {
+                HeaderView(heading: "마켓")
+                
+                SearchBarView(searchText: $searchText)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 20)
+                
+                if !records.isEmpty {
+                    RecentCoinSectionView(coins: records.compactMap { store.coinMeta[$0.query] }, deleteAction: { coin in
+                        store.deleteRecord(coin.id)
+                    }) { selectedCoinID = $0 }
                 }
 
                 VStack(spacing: 16) {
@@ -54,6 +53,7 @@ struct MarketView: View {
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.bottom, 4)
 
                     CoinListView(store: store, selectedCoinID: $selectedCoinID, searchText: $searchText)
                 }

--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -80,8 +80,6 @@ struct MarketView: View {
                 CoinDetailView(coin: coin)
                     .id(coin.id)
                 
-            } else {
-                Text("Empty")
             }
         }
         .navigationSplitViewStyle(.balanced)

--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -92,7 +92,7 @@ struct MarketView: View {
 #Preview {
     MarketView(
         coinService: UpBitAPIService(),
-        tickerService: UpbitTickerService(client: 
+        tickerService: UpbitTickerService(client:
                                           ReconnectableWebSocketClient {
                                           BaseWebSocketClient(url: URL(string: "wss://api.upbit.com/websocket/v1")!)
                                           })

--- a/AIProject/AIProject/Features/Market/SubView/CoinCell.swift
+++ b/AIProject/AIProject/Features/Market/SubView/CoinCell.swift
@@ -112,7 +112,7 @@ fileprivate struct CoinPriceView: View {
                         Rectangle()
                             .fill(.clear)
                             .frame(width: proxy.size.width, height: 1)
-                            .blinkBorderOnChange(ticker.snapshot.price, duration: .milliseconds(500), color: .aiCoLabel, lineWidth: 2, cornerRadius:1)
+                            .blinkBorderOnChange(ticker.snapshot.price, duration: .milliseconds(400), color: .aiCoLabel, lineWidth: 1, cornerRadius:0.5)
                             .offset(y: proxy.size.height + 1)
                     }
                 }

--- a/AIProject/AIProject/Features/Market/SubView/RecentCoinSectionView.swift
+++ b/AIProject/AIProject/Features/Market/SubView/RecentCoinSectionView.swift
@@ -14,7 +14,7 @@ struct RecentCoinSectionView: View {
 
     var body: some View {
         ScrollView(.horizontal) {
-            HStack {
+            HStack(spacing: 8) {
                 ForEach(coins) { coin in
                     HStack(spacing: 8) {
                         Text(coin.koreanName)

--- a/AIProject/AIProject/Features/Search/SearchBarView.swift
+++ b/AIProject/AIProject/Features/Search/SearchBarView.swift
@@ -16,6 +16,7 @@ struct SearchBarView: View {
         HStack(spacing: 10) {
             HStack {
                 Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.aiCoLabel)
 
                 TextField("코인 이름으로 검색하세요", text: $searchText)
                     .padding(.horizontal, 8)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- close #347 
- close #349 
- close #359 
- close #379 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- Selected Tab을 받아올 수 있는 Route 객체 생성
- Tab을 enum으로 리팩토링

```swift

struct MainTabView: View {
    @State private var router = TabRouter()
    private let tickerService: RealTimeTickerProvider = UpbitTickerService()
    private let upbitService: UpBitAPIService = UpBitAPIService()
    
    var body: some View {
        TabView(selection: $router.selected) {
            ForEach(TabFeature.allCases) { tab in
                makeTab(tab)
                    .tabItem {
                        Label(tab.rawValue, systemImage: tab.icon)
                    }
                    .tag(tab)
            }
        }
        .environment(router)
    }
    
    @ViewBuilder func makeTab(_ tab: TabFeature) -> some View { ... }
}
```
- 각 Tab 뷰 생성 ViewBuilder로 변경하였으나, Service를 매번 다시 만들어서 서비스 생명 주기를 Maintab으로 옮김

### 이슈
- TabView 생성 시, 아직 열리지 않은 Tab을 미리 생성해두어서 아래 문제 발생
- 아직 보이지 않았음에도 onApeear가 호출 되어 State가 깨짐

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

- 패딩 적용하였습니다. 서치바 하단 20, 북마크 하단 20, 북마크와 서치 레코드 사이 16, 서치 레코드 간격 8
<img width="40%" height="2622" alt="image" src="https://github.com/user-attachments/assets/704a977f-b4f2-42af-bbf7-65ee207fb661" />

<img width="40%" height="2622" alt="image" src="https://github.com/user-attachments/assets/0711b261-e820-41c2-a51d-5990ddd9d5ce" />



- MainTab 생성 부분 변경되었고, TabRouter를 사용하실 분들은 아래 처럼 사용하시면 됩니다.
 ```swift
 @Environment(TabRouter.self) private var router
 
 .onChange(of: router.selected) { ... }
 ```
 
