### PR TITLE
코인 상세 - 차트 x축의 오른쪽 시간이 가려지는 현상 해결

### DIFF
--- a/AIProject/AIProject/Core/Util/Calendar+Util.swift
+++ b/AIProject/AIProject/Core/Util/Calendar+Util.swift
@@ -1,0 +1,29 @@
+//
+//  Calendar+Util.swift
+//  AIProject
+//
+//  Created by 강민지 on 8/26/25.
+//
+
+import Foundation
+
+/// 지정 타임존을 적용한 Gregorian 캘린더를 생성하는 유틸리티.
+///
+/// - Parameter timeZone: 계산에 사용할 타임존(예: `"Asia/Seoul"`).
+/// - Returns: 지정 타임존을 포함한 `Calendar(identifier: .gregorian)`.
+///
+/// - 설명:
+///   라벨 포맷터가 사용하는 타임존과 동일한 캘린더로
+///   X축 틱(00/15/30/45) 생성과 정시(00분) 그리드 판정을 수행할 때 사용합니다.
+///   이렇게 하면 라벨과 그리드가 정확히 정렬됩니다.
+///
+/// - 사용 예시:
+///   let tz = TimeZone(identifier: "Asia/Seoul") ?? .current
+///   let cal = Calendar.gregorian(timeZone: tz)
+extension Calendar {
+    static func gregorian(timeZone: TimeZone) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+}

--- a/AIProject/AIProject/Core/Util/Date+Util.swift
+++ b/AIProject/AIProject/Core/Util/Date+Util.swift
@@ -25,9 +25,32 @@ extension Date {
         formatter.locale = Locale(identifier: "ko_KR")
         return formatter
     }()
-    
+
     var dateAndTime: String {
         Date.dateAndTimeFormatter.string(from: self)
+    }}
+
+/// `Date` 타입에 시간을 지정된 형식으로 포맷팅하는 기능을 추가하는 확장.
+///
+/// - Static Property:
+///   - hhmmTimeFormatter: `"HH:mm"` 형식(24시간제)의 `DateFormatter`.
+///
+/// - Computed Property:
+///   - hhmmTime: `Date` 인스턴스를 지정된 형식의 문자열로 변환.
+///
+/// 사용 예시:
+/// let now = Date()
+/// print(now.hhmmTime) // "13:05"
+extension Date {
+    static let hhmmTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter
+    }()
+ 
+    var hhmmTime: String {
+        Date.hhmmTimeFormatter.string(from: self)
     }
     
     static let numbersOnlyFormatter: DateFormatter = {
@@ -41,3 +64,4 @@ extension Date {
         Date.numbersOnlyFormatter.string(from: self)
     }
 }
+

--- a/AIProject/AIProject/Features/CoinDetail/View/CandleChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CandleChartView.swift
@@ -53,7 +53,7 @@ struct CandleChartView: View {
                     x: .value("Date", point.date),
                     yStart: .value("Open", point.open),
                     yEnd: .value("Close", point.close),
-                    width: 6
+                    width: 4
                 )
                 .foregroundStyle( point.close >= point.open ? positiveColor : negativeColor )
             }

--- a/AIProject/AIProject/Features/CoinDetail/View/CandleChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CandleChartView.swift
@@ -19,6 +19,25 @@ struct CandleChartView: View {
     let negativeColor: Color
     
     var body: some View {
+        /// 라벨과 같은 타임존의 캘린더로 틱/그리드 계산
+        let timeZone  = timeFormatter.timeZone ?? .current
+        let calendar = Calendar.gregorian(timeZone: timeZone)
+
+        /// X축 틱: 항상 00/15/30/45만 생성
+        let rawTicks = quarterTicksStrict(in: xDomain, calendar: calendar)
+
+        /// 라벨 경계 버퍼
+        /// 우측 경계로부터 3분 이내 라벨은 숨김 (클리핑/치우침 방지)
+        let step: TimeInterval = 15 * 60
+        let buffer = step * 0.2 // 15분의 20% = 3분
+        
+        /// 라벨 기준: 도메인 상한이 아니라 실제 보이는 오른쪽 끝 "마지막 캔들 시각"을 사용
+        let lastDataX = data.last?.date ?? xDomain.upperBound
+        let visibleRight = lastDataX
+        
+        /// 버퍼 이내(경계 근접) 라벨은 숨김
+        let ticks = rawTicks.filter { $0.addingTimeInterval(buffer) <= visibleRight }
+        
         Chart {
             ForEach(data, id: \.date) { point in
                 /// 고가/저가 수직선 표시 (위꼬리/아래꼬리 역할)
@@ -47,20 +66,13 @@ struct CandleChartView: View {
         .chartYScale(domain: yRange)
         /// 한 화면에서 보이는 X축 범위 (2880초 = 48분)
         .chartXVisibleDomain(length: 2880)
-        /// X축 눈금 (15분 간격) + 1시간마다 세로선 표시
+        /// X축 눈금: 고정 틱 사용(15분 간격) + 정시에만 세로선
         .chartXAxis {
-            AxisMarks(values: .stride(by: .minute, count: 15)) { value in
+            AxisMarks(values: ticks) { value in
                 AxisTick()
-                AxisValueLabel {
-                    if let date = value.as(Date.self) {
-                        Text(timeFormatter.string(from: date))
-                    }
-                }
-                
-                /// 세로선은 1시간 단위(분 == 0)일 때만 표시
-                if let date = value.as(Date.self),
-                   Calendar.current.component(.minute, from: date) == 0 {
-                    AxisGridLine()
+                if let date = value.as(Date.self) {
+                    AxisValueLabel { Text(timeFormatter.string(from: date)) } // 00/15/30/45분에만 노출
+                    if calendar.component(.minute, from: date) == 0 { AxisGridLine() } // 00분에만 세로 선
                 }
             }
         }
@@ -81,7 +93,45 @@ struct CandleChartView: View {
                 }
             }
         }
-        /// 차트 오른쪽 영역에 여백 추가
-        .chartPlotStyle { $0.padding(.trailing, 10).padding(.bottom, 8) }
+        /// 차트 오른쪽 영역에 여백 추가: 라벨/마지막 캔들 여유
+        .chartPlotStyle { $0.padding(.trailing, 20).padding(.bottom, 8) }
+    }
+    
+    // MARK: - Quarter Ticks (strict 00/15/30/45)
+    /// 정각·15·30·45 분 틱 생성 (안전 처리)
+    private func quarterTicksStrict(in domain: ClosedRange<Date>, calendar: Calendar) -> [Date] {
+        // 시(hour) 시작 시각 계산(실패 시 합리적 폴백)
+        let hourStart: Date = {
+            if let interval = calendar.dateInterval(of: .hour, for: domain.lowerBound) {
+                return interval.start
+            } else {
+                var components = calendar.dateComponents([.year, .month, .day, .hour], from: domain.lowerBound)
+                components.minute = 0
+                components.second = 0
+                components.nanosecond = 0
+                return calendar.date(from: components) ?? domain.lowerBound
+            }
+        }()
+
+        var cursor = hourStart
+        var ticks: [Date] = []
+
+        while cursor <= domain.upperBound {
+            for minute in [0, 15, 30, 45] {
+                var components = calendar.dateComponents([.year, .month, .day, .hour], from: cursor)
+                components.minute = minute
+                components.second = 0
+                components.nanosecond = 0
+
+                if let tick = calendar.date(from: components), domain.contains(tick) {
+                    ticks.append(tick)
+                }
+            }
+            guard let nextHour = calendar.date(byAdding: .hour, value: 1, to: cursor) else {
+                break
+            }
+            cursor = nextHour
+        }
+        return ticks.sorted()
     }
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -47,9 +47,9 @@ struct ChartView: View {
     
     /// 뷰 전용 매핑 (테마/색)
     private var headerColor: Color {
-        let v = viewModel.displayChangeValue
-        if v > 0 { return themeManager.selectedTheme.positiveColor }
-        if v < 0 { return themeManager.selectedTheme.negativeColor }
+        let value = viewModel.displayChangeValue
+        if value > 0 { return themeManager.selectedTheme.positiveColor }
+        if value < 0 { return themeManager.selectedTheme.negativeColor }
         return .gray
     }
     

--- a/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ChartView.swift
@@ -42,7 +42,7 @@ struct ChartView: View {
     /// 뷰모델이 제공하는 기준 시각 사용 (없으면 빈 문자열)
     private var lastUpdatedText: String {
         guard let time = viewModel.lastUpdated else { return "" }
-        return DateFormatter.stampYMdHmKST.string(from: time) + " 기준"
+        return time.dateAndTime + " 기준"
     }
     
     /// 뷰 전용 매핑 (테마/색)
@@ -172,7 +172,7 @@ struct ChartView: View {
                     xDomain: xDomain,
                     yRange: yRange,
                     scrollTo: scrollTo,
-                    timeFormatter: viewModel.timeFormatter,
+                    timeFormatter: Date.hhmmTimeFormatter,
                     positiveColor: themeManager.selectedTheme.positiveColor,
                     negativeColor: themeManager.selectedTheme.negativeColor
                 )
@@ -184,13 +184,4 @@ struct ChartView: View {
 #Preview {
     ChartView(coin: Coin(id: "KRW-BTC", koreanName: "비트코인"))
         .environmentObject(ThemeManager())
-}
-
-private extension DateFormatter {
-    static let stampYMdHmKST: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy.MM.dd HH:mm"
-        formatter.locale = Locale(identifier: "ko_KR")
-        return formatter
-    }()
 }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -354,15 +354,6 @@ extension ChartViewModel {
     func scrollToTime(for data: [CoinPrice]) -> Date {
         data.last?.date.addingTimeInterval(60 * 5) ?? Date()
     }
-    
-    /// 차트 X축 라벨에 사용할 시간 포맷터 (24시간제 HH:mm 형식)
-    /// - Returns: "HH:mm" 포맷을 사용하는 DateFormatter (ko_KR 로케일)
-    var timeFormatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        formatter.locale = Locale(identifier: "ko_KR")
-        return formatter
-    }
 }
 
 extension ChartViewModel {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #321 

## 📝 작업 내용

- X축 라벨 안정화(+3분 버퍼) 
  - `00/15/30/45` 고정
  - 맨 우측 실제 라벨에 + 3분 버퍼를 더해 경계에 있는 라벨이 숨겨지는 문제 해결
  - trailing padding `10` -> `20`로 증가시켜 그래프 오른쪽 여유 공간 더 확보
- 캔들 바 두께 조정
  - 캔들 바 두께를 `6` -> `4`로 줄여서 간혹가다 캔들끼리 겹치는 현상 해결
- 날짜/시간/캘린더 유틸 공용화 
  - `Date+Util`에 `HH:mm` 포맷 추가
  - `Calendar+Util` 파일 생성하여 `gregorian` 타임존 추가 (그래프의 선의 위치를 시간 라벨과 일치시키기 위해 필요)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

특별히 없습니다!  
살펴보고 싶으시다면
- 버퍼 3분 기본값 OK? (1–2분로 조정 여부)
- 바 두께 4 가독성(특히 작은 화면) 괜찮은지
보시면 될 거 같습니다.