### PR TITLE
'시세', '보고서' 탭 전환 시에도 보고서 컨텐츠 유지

### DIFF
--- a/AIProject/AIProject/Domain/Model/Common/Prompt.swift
+++ b/AIProject/AIProject/Domain/Model/Common/Prompt.swift
@@ -39,7 +39,7 @@ enum Prompt {
                 let description: String
             }
             
-            "\(coinKName)" 개요를 위 JSON 형식으로 작성 (마크다운 금지)
+            "\(coinKName)" 개요를 위 JSON 형식으로 작성 (마크다운 금지, 출처 제외)
             """
         case .generateTodayNews(let coinKName):
             """
@@ -54,10 +54,10 @@ enum Prompt {
                 let newsSourceURL: String
             }
 
-            1. 현재 국내 시간을 기준으로 최근 24시간 뉴스 기반
-            2. 뉴스 전반을 분석해 시장 분위기를 요약
+            1. 현재 국내 시간을 기준으로 최근 24시간 뉴스를 분석해 \(coinKName)시장 분위기를 요약
+            2. 분석하는데 사용된 뉴스 중 3개를 뉴스 배열에 제목, 요약, 해당 뉴스 출처 링크를 담아 전달
 
-            위 조건에 따라 "\(coinKName)"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
+            위 조건에 따라 "\(coinKName)"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지, 답변에 출처 금지)
             """
         case .generateWeeklyTrends(let coinKName):
             """
@@ -69,7 +69,7 @@ enum Prompt {
 
             1. 현재 국내 시간을 기준으로 일주일 동안의 정보 사용
 
-            위 조건에 따라 "\(coinKName)"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
+            위 조건에 따라 "\(coinKName)"에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지, 출처 제외)
             """
         case .extractCoinID(let text):
             """
@@ -91,7 +91,7 @@ enum Prompt {
             1. 현재 국내 시간을 기준으로 최근 2시간 뉴스 기반
             2. 뉴스 전반을 분석해 시장 분위기를 요약 
             
-            위 조건에 따라 암호화폐 전체 시장에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지)
+            위 조건에 따라 암호화폐 전체 시장에 대한 내용을 위 JSON 형식으로 작성 (마크다운 금지, 출처 제외)
             """
         case.generateCommunityInsight(let redditPost):
             """
@@ -105,7 +105,7 @@ enum Prompt {
                 let summary: String
             }
             
-            이 게시물들을 InsightDTO를 기반으로 JSON으로 응답해줘.
+            이 게시물들을 InsightDTO를 기반으로 JSON으로 응답해줘(마크다운 금지, 출처 제외).
             """
         case .generateBookmarkBriefing(let importance, let bookmarks):
             """

--- a/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
@@ -10,8 +10,14 @@ import SwiftUI
 struct CoinDetailView: View {
     @Environment(\.horizontalSizeClass) var hSizeClass
     @State private var selectedTab: Tab = .chart
+    @StateObject var reportViewModel: ReportViewModel
     
     let coin: Coin
+    
+    init(coin: Coin) {
+        self.coin = coin
+        _reportViewModel = StateObject(wrappedValue: ReportViewModel(coin: coin))
+    }
     
     var body: some View {
         GeometryReader { proxy in
@@ -20,7 +26,13 @@ struct CoinDetailView: View {
                     // 헤더
                     if hSizeClass == .regular {
                         HStack(alignment: .lastTextBaseline) {
-                            HeaderView(heading: coin.koreanName) // FIXME: 코인 심볼
+                            Text(coin.koreanName)
+                                .font(.system(size: 24, weight: .black))
+                                .foregroundStyle(.aiCoLabel)
+                            
+                            Text(coin.coinSymbol)
+                                .font(.system(size: 20, weight: .semibold))
+                                .foregroundStyle(.aiCoLabelSecondary)
                         }
                     } else {
                         HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -61,7 +73,7 @@ struct CoinDetailView: View {
                             ChartView(coin: coin)
                                 .frame(height: proxy.size.height * 0.55)
                             
-                            ReportView(coin: coin)
+                            ReportView(viewModel: reportViewModel)
                                 .padding(.top, 20)
                         } else {
                             switch selectedTab {
@@ -69,7 +81,7 @@ struct CoinDetailView: View {
                                 ChartView(coin: coin)
                                     .frame(height: proxy.size.height * 0.8)
                             case .report:
-                                ReportView(coin: coin)
+                                ReportView(viewModel: reportViewModel)
                             }
                         }
                     }

--- a/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
@@ -90,6 +90,9 @@ struct CoinDetailView: View {
             }
             .scrollIndicators(.hidden)
         }
+        .onDisappear {
+            reportViewModel.cancelAll()
+        }
         //        .toolbar(.hidden, for: .navigationBar)
     }
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportNewsSectionView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportNewsSectionView.swift
@@ -43,12 +43,9 @@ struct ReportNewsSectionView: View {
                         Spacer()
                         
                         RoundedButton(title: "원문보기", imageName: "chevron.right") {
-                            // FIXME: 앨런에게서 뉴스 출처 url 받아오기
-                            // if let url = URL(string: article.newsSourceURL) {
-                            //     safariItem = IdentifiableURL(url: url)
-                            // }
-                            
-                            safariItem = IdentifiableURL(url: URL(string: "https://www.blockmedia.co.kr/archives/960242")!)
+                             if let url = URL(string: article.newsSourceURL) {
+                                 safariItem = IdentifiableURL(url: url)
+                             }
                         }
                     }
                     

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -15,11 +15,7 @@ import SwiftUI
 ///   - coin: 리포트를 보여줄 대상 코인
 struct ReportView: View {
     @Environment(\.horizontalSizeClass) var hSizeClass
-    @StateObject var viewModel: ReportViewModel
-    
-    init(coin: Coin) {
-        _viewModel = StateObject(wrappedValue: ReportViewModel(coin: coin))
-    }
+    @ObservedObject var viewModel: ReportViewModel
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -47,10 +43,11 @@ struct ReportView: View {
             }
         }
         .padding(.bottom, 30)
+        .task {
+            await viewModel.load()
+        }
+        .onDisappear {
+            viewModel.cancelAll()
+        }
     }
-}
-
-#Preview {
-    let sampleCoin = Coin(id: "KRW-BTC", koreanName: "비트코인")
-    return ScrollView { ReportView(coin: sampleCoin).padding(.horizontal, 16) }
 }

--- a/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/ReportView.swift
@@ -44,10 +44,7 @@ struct ReportView: View {
         }
         .padding(.bottom, 30)
         .task {
-            await viewModel.load()
-        }
-        .onDisappear {
-            viewModel.cancelAll()
+            await viewModel.startIfNeeded()
         }
     }
 }

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
@@ -35,6 +35,8 @@ final class ReportViewModel: ObservableObject {
     private var weeklyTask: Task<CoinWeeklyDTO, Error>?
     private var todayTask: Task<CoinTodayNewsDTO, Error>?
     
+    private var hasStarted = false
+    
     init(coin: Coin) {
         self.coin = coin
         self.koreanName = coin.koreanName
@@ -82,6 +84,14 @@ final class ReportViewModel: ObservableObject {
         await updateWeeklyUI()
         try? await Task.sleep(for: .milliseconds(350)) // UI가 순차적으로 적용되는 효과를 주기 위한 딜레이
         await updateTodayUI()
+    }
+    
+    /// 탭에서 Report가 처음 표시될 때 한 번만 로드합니다.
+    @MainActor
+    func startIfNeeded() async {
+        guard !hasStarted else { return }
+        hasStarted = true
+        await load()
     }
     
     // overview만 다시 시도

--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ReportViewModel.swift
@@ -38,14 +38,12 @@ final class ReportViewModel: ObservableObject {
     init(coin: Coin) {
         self.coin = coin
         self.koreanName = coin.koreanName
-        
-        load()
     }
     
-    private func load() {
+    func load() async {
         cancelAll()
         
-        Task { @MainActor in
+        await MainActor.run {
             overview = .loading
             weekly = .loading
             today = .loading
@@ -79,13 +77,11 @@ final class ReportViewModel: ObservableObject {
             )
         }
         
-        Task {
-            await updateOverviewUI()
-            try? await Task.sleep(for: .milliseconds(350)) // UI가 순차적으로 적용되는 효과를 주기 위한 딜레이
-            await updateWeeklyUI()
-            try? await Task.sleep(for: .milliseconds(350)) // UI가 순차적으로 적용되는 효과를 주기 위한 딜레이
-            await updateTodayUI()
-        }
+        await updateOverviewUI()
+        try? await Task.sleep(for: .milliseconds(350)) // UI가 순차적으로 적용되는 효과를 주기 위한 딜레이
+        await updateWeeklyUI()
+        try? await Task.sleep(for: .milliseconds(350)) // UI가 순차적으로 적용되는 효과를 주기 위한 딜레이
+        await updateTodayUI()
     }
     
     // overview만 다시 시도


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- close #376

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- @StateObject ReportViewModel 생성 위치를 ReportView에서 CoinDetailView로 이동했습니다.
    - CoinDetailView에서 차트만 보고 나가는 경우에는 토큰을 사용하지 않도록 load()를 init에서 삭제하고 ReportView .task에서 startIfNeeded()호출
    - startIfNeeded()는 hasStarted 변수를 사용해서 hasStarted가 false일 때만 load()가 호출될 수 있도록 수정했습니다. (탭 전환시에는 호출되지 않도록 하기 위함)
    - startIfNeeded() / load() 메서드를 async로 변경하여 ReportView의 .task 블록에서 await 호출이 가능하게 수정
        - View 생명주기와 연동되어, View가 해제되면 .task가 취소되고 load 내부의 비동기 처리도 안전하게 종료되도록 하기 위함
        - 현재 load() 내부 Task까지는 취소가 전파되지 않음 (추후 고도화 예정)
    - CoinDetailView()가 disappear 되는 경우 실행 중인 task가 있다면 취소

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- 테스트
    - 탭 전환될 때는 네트워크 요청 X
    - CoinDetailView가 disappear되는 경우에만 실행중인 task cancel
        - 네트워크 요청 중이라면 탭 전환되어도 이어서 계속 요청함
- 아이패드 코인 상세 뷰 Header는 HeaderView 수정되면 맞춰서 수정하겠습니다!
- vm 생명주기에 관련해서 이슈 생성해뒀습니다.
   - #386 