### PR TITLE
투자 성향 선택 애니메이션 ThemeView와 통일

### DIFF
--- a/AIProject/AIProject/Features/Onboarding/LastOnboardingPage.swift
+++ b/AIProject/AIProject/Features/Onboarding/LastOnboardingPage.swift
@@ -31,9 +31,10 @@ struct LastOnboardingPage: View {
                 RoundedRectangleFillButton(
                     title: type.rawValue,
                     isHighlighted: Binding(get: { selectedType == type }, set: { _ in })) {
-                        selectedType = type
+                        withAnimation(.snappy) {
+                                selectedType = type
+                            }
                     }
-                    .animation(.easeInOut(duration: 0.15), value: selectedType)
             }
             .padding(.horizontal, 16)
             
@@ -51,7 +52,6 @@ struct LastOnboardingPage: View {
                 }
                 onFinish()
             }
-            .animation(.easeInOut(duration: 0.15), value: selectedType)
             .disabled(selectedType == nil)
             .opacity(selectedType == nil ? 0.5 : 1)
             .padding(.horizontal, 16)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- close #367 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 기존 easeInOut이었던 투자 성향 선택 애니메이션을 ThemeView와(snappy) 통일

### 스크린샷 (선택)

https://github.com/user-attachments/assets/a29faa13-c299-4417-9ffe-dd611ccaad90

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
- 프레임을 쪼개보면 투자성향 버튼과 시작하기 버튼의 애니메이션 시작 시점이 미세하게 다릅니다.(시작하기가 느림) 실제로는 티가 아예 안나는 것 같은데 영상 확인 부탁드립니다!