### PR TITLE
마이페이지 - 테마 변경 화면 하단에 캔들차트 미리보기 추가

### DIFF
--- a/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel+Dummy.swift
+++ b/AIProject/AIProject/Features/CoinDetail/ViewModel/ChartViewModel+Dummy.swift
@@ -9,42 +9,84 @@ import Foundation
 
 // MARK: - Dummy Data Generator
 extension ChartViewModel {
-    /// 지정한 시간 범위와 샘플링 간격으로 더미 시계열 가격을 생성
-    /// - Parameters:
-    ///   - hours: 과거로부터 생성할 시간 범위 (시간 단위, 예: 24)
-    ///   - samplingInterval: 샘플 간격 (초, 예: 60 → 1분)
-    /// - Returns: 생성된 `CoinPrice` 시계열 배열
+    /// 지정된 시간 동안, 일정 간격으로 "항상 같은 모양"의 차트 더미 데이터를 생성
     static func makeDummyPrices(hours: Double, samplingInterval: TimeInterval) -> [CoinPrice] {
-        let now = Date()
-        let startDate = now.addingTimeInterval(-hours * 3600)
-        let sampleCount = Int((hours * 3600) / samplingInterval)
-        
-        var priceSeries: [CoinPrice] = []
-        var currentTimestamp = startDate
-        var value = 100.0
-        
+        // 현재 시간을 샘플 간격에 맞춰 고정 (항상 같은 시각 기준에서 시작)
+        let nowSeconds = Date().timeIntervalSince1970
+        let fixedNowSeconds = floor(nowSeconds / samplingInterval) * samplingInterval
+        let now = Date(timeIntervalSince1970: fixedNowSeconds)
+
+        // 총 샘플 개수와 시작 시각
+        let totalSeconds = hours * 3600
+        let sampleCount = max(1, Int(totalSeconds / samplingInterval))
+        let startDate = now.addingTimeInterval(-totalSeconds)
+
+        // 항상 같은 난수 시퀀스를 만들기 위한 내부 값
+        var randomSeed: UInt64 = 2025
+        @inline(__always) func randomUnit() -> Double {
+            // 0~1 사이 값 고정 생성 (항상 같은 결과)
+            randomSeed &+= 0x9E3779B97F4A7C15
+            var tmp = randomSeed
+            tmp = (tmp ^ (tmp >> 30)) &* 0xBF58476D1CE4E5B9
+            tmp = (tmp ^ (tmp >> 27)) &* 0x94D049BB133111EB
+            let r = tmp ^ (tmp >> 31)
+            return Double(r & 0x1F_FFFF_FFFF_FFFF) / Double(0x1F_FFFF_FFFF_FFFF)
+        }
+        @inline(__always) func randomNoise(_ range: Double) -> Double {
+            // -range ~ +range 사이 값
+            (randomUnit() - 0.5) * 2.0 * range
+        }
+
+        // 기본 가격과 파동 크기 설정 (단순 시각용)
+        let basePrice = 100.0
+        let bigWaveHeight = 0.8      // 큰 파동 세기
+        let bigWavePeriod = 24.0     // 큰 파동 주기
+        let smallWaveHeight = 0.35   // 작은 파동 세기
+        let smallWavePeriod = 7.0    // 작은 파동 주기
+        let priceJitter = 0.35       // 매번 조금씩 흔들림
+        let wickJitter = 0.45        // 꼬리 길이 흔들림
+        let minWickLength = 0.10     // 최소 꼬리 길이
+
+        var prices: [CoinPrice] = []
+        prices.reserveCapacity(sampleCount)
+
+        var currentTime = startDate
+        var lastClose = basePrice
+
         for i in 0..<sampleCount {
-            let open = value
-            let close = value + Double.random(in: -2...2)
-            let high = max(open, close) + Double.random(in: 0...1)
-            let low = min(open, close) - Double.random(in: 0...1)
-            let tradeValue = Double.random(in: 50_000_000...200_000_000)
-            
-            priceSeries.append(
+            // 파동 + 작은 흔들림
+            let wave = bigWaveHeight * sin(Double(i) * (2 * .pi / bigWavePeriod))
+                     + smallWaveHeight * cos(Double(i) * (2 * .pi / smallWavePeriod))
+            let stepChange = randomNoise(priceJitter)
+
+            let open = lastClose
+            let close = lastClose + stepChange + wave * 0.04
+
+            var high = max(open, close) + max(minWickLength, abs(randomNoise(wickJitter)))
+            var low  = min(open, close) - max(minWickLength, abs(randomNoise(wickJitter)))
+
+            // 꼬리값이 뒤집히지 않게 보정
+            if high < max(open, close) { high = max(open, close) + minWickLength }
+            if low  > min(open, close) { low  = min(open, close) - minWickLength }
+
+            let tradeVolume = 120_000_000.0 + Double(i % 31) * 1_000_000.0 + randomNoise(500_000.0)
+
+            prices.append(
                 CoinPrice(
-                    date: currentTimestamp,
+                    date: currentTime,
                     open: open,
                     high: high,
                     low: low,
                     close: close,
-                    trade: tradeValue,
+                    trade: tradeVolume,
                     index: i
                 )
             )
-            
-            currentTimestamp = currentTimestamp.addingTimeInterval(samplingInterval)
-            value = close
+
+            currentTime = currentTime.addingTimeInterval(samplingInterval)
+            lastClose = close
         }
-        return priceSeries
+
+        return prices
     }
 }

--- a/AIProject/AIProject/Features/MyPage/View/Theme/ThemePreviewChartView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/Theme/ThemePreviewChartView.swift
@@ -1,0 +1,118 @@
+//
+//  ThemePreviewChartView.swift
+//  AIProject
+//
+//  Created by 강민지 on 8/27/25.
+//
+
+import SwiftUI
+import Charts
+
+/// 단일 캔들(몸통+꼬리)을 그리는 마크
+@ChartContentBuilder
+private func candleMark(
+    _ price: CoinPrice,
+    theme: Theme,
+    widthSec: TimeInterval,
+    wickWidthSec: TimeInterval
+) -> some ChartContent {
+    let isUp = price.close >= price.open
+    let color = isUp ? theme.positiveColor : theme.negativeColor
+    let bodyMin = min(price.open, price.close)
+    let bodyMax = max(price.open, price.close)
+    
+    // 꼬리 길이 (몸통 대비 20% 이내로 제한)
+    let bodyH = max(bodyMax - bodyMin, 0.001)
+    let maxWickLen = max(0.04, bodyH * 0.20)
+    let wickHigh = min(price.high, bodyMax + maxWickLen)
+    let wickLow  = max(price.low,  bodyMin - maxWickLen)
+    
+    // 시간 기반 폭 (몸통/꼬리 두께)
+    let halfCandle = widthSec / 2
+    let halfWick   = wickWidthSec / 2
+    
+    // 꼬리 (위아래 라인)
+    RectangleMark(
+        xStart: .value("Time", price.date.addingTimeInterval(-halfWick)),
+        xEnd:   .value("Time", price.date.addingTimeInterval(+halfWick)),
+        yStart: .value("Price", wickLow),
+        yEnd:   .value("Price", wickHigh)
+    )
+    .foregroundStyle(color)
+    
+    // 몸통 (실제 캔들 영역)
+    RectangleMark(
+        xStart: .value("Time", price.date.addingTimeInterval(-halfCandle)),
+        xEnd:   .value("Time", price.date.addingTimeInterval(+halfCandle)),
+        yStart: .value("Price", bodyMin),
+        yEnd:   .value("Price", bodyMax)
+    )
+    .foregroundStyle(color)
+}
+
+/// 캔들 차트 프리뷰 뷰 (테마 색상 변경 미리보기용)
+struct CandlestickPreviewView: View {
+    @EnvironmentObject var themeManager: ThemeManager
+    
+    /// 더미 데이터 (24시간, 1분 단위)
+    @State private var prices: [CoinPrice] =
+    ChartViewModel.makeDummyPrices(hours: 24, samplingInterval: 60)
+    
+    var body: some View {
+        let theme = themeManager.selectedTheme
+        
+        VStack(spacing: 8) {
+            Text("preview")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            
+            chartView(theme: theme)
+                .frame(height: 220)
+        }
+        .padding(16)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).strokeBorder(.quaternary, lineWidth: 0.5))
+        .padding(.horizontal, 16)
+    }
+    
+    /// 캔들스틱 차트를 그리는 뷰 (최근 24개 봉만)
+    @ViewBuilder
+    private func chartView(theme: Theme) -> some View {
+        // 보여지는 캔들 바 갯수
+        let visiblePrices = Array(prices.suffix(24))
+        
+        if visiblePrices.count < 2 {
+            Color.clear
+        } else {
+            let first = visiblePrices.first!
+            let last  = visiblePrices.last!
+            let interval = visiblePrices[1].date.timeIntervalSince(visiblePrices[0].date)
+            
+            // 간단한 튜닝: 몸통/꼬리 두께 비율
+            let candleWidthSec = interval * 0.55
+            let wickWidthSec   = max(interval * 0.24, 0.9)
+            
+            // X축 도메인: 양 끝에 반 간격 여유
+            let domainStart = first.date.addingTimeInterval(-interval * 0.5)
+            let domainEnd   = last.date.addingTimeInterval( +interval * 0.5)
+
+            let minLow  = visiblePrices.map(\.low).min()!
+            let maxHigh = visiblePrices.map(\.high).max()!
+            let yPad = max((maxHigh - minLow) * 0.03, 0.01)   // 아주 얕은 패딩
+
+            
+            Chart {
+                ForEach(visiblePrices, id: \.index) { price in
+                    candleMark(price,
+                               theme: theme,
+                               widthSec: candleWidthSec,
+                               wickWidthSec: wickWidthSec)
+                }
+            }
+            .chartXAxis(.hidden)
+            .chartYAxis(.hidden)
+            .chartXScale(domain: domainStart...domainEnd)
+            .chartYScale(domain: (minLow - yPad)...(maxHigh + yPad))
+        }
+    }
+}

--- a/AIProject/AIProject/Features/MyPage/View/Theme/ThemeView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/Theme/ThemeView.swift
@@ -33,6 +33,26 @@ struct ThemeView: View {
             .buttonStyle(.plain)
             
             Spacer(minLength: 0)
+            
+            /// 미리보기 차트 섹션
+            VStack(alignment: .leading, spacing: 8) {
+                Label {
+                    Text("색상을 변경하면 아래 미리보기 색상이 변경됩니다.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } icon: {
+                    Image(systemName: "chart.xyaxis.line") // 또는 "waveform.path.ecgscope"로 골라봤습니다.
+                        .font(.caption)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 16)
+                
+                CandlestickPreviewView()
+            }
+            .transition(.opacity.combined(with: .scale))
+            
+            Spacer(minLength: 0)
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #395 

## 📝 작업 내용

- `ThemePreviewChartView` 추가 (캔들 차트 프리뷰 View)
- `ThemeView`에 프리뷰 스택 연결 → 테마 색상 변경 시 즉시 반영
  - 색상을 변경하면 아래 미리보기 색상이 변경됩니다." 텍스트 옆에 아이콘을 넣었습니다. 
  아이콘 모양은 `chart.xyaxis.line` 또는 `waveform.path.ecgscope`로 골라봤습니다.
  
    ```Swift
    Label {
        Text("색상을 변경하면 아래 미리보기 색상이 변경됩니다.")
            .font(.caption)
            .foregroundStyle(.secondary)
    } icon: {
        Image(systemName: "chart.xyaxis.line") // 또는 "waveform.path.ecgscope"로 골라봤습니다.
            .font(.caption)
            .symbolRenderingMode(.hierarchical)
            .foregroundStyle(.secondary)
    }
    .padding(.horizontal, 16)
    ```
   - 디자인 변경하실 때 아이콘을 빼고 텍스트만 나오게 바꾸셔도 됩니다.
      ```Swift
      Label {
          Text("색상을 변경하면 아래 미리보기 색상이 변경됩니다.")
              .font(.caption)
              .foregroundStyle(.secondary)
      } 
      .padding(.horizontal, 16)
      ```
- `ChartViewModel+Dummy` 더미 데이터를 생성할 때마다 바뀌는 랜덤값이 아닌, 실행마다 동일한 고정된 형태로 변경

### 스크린샷 (선택)
<img height="450" alt="스크린샷 2025-08-27 오후 1 41 02" src="https://github.com/user-attachments/assets/2f3aaf98-a05f-47b8-a501-e18538fafb4a" />


## 💬 리뷰 요구사항(선택)

- 프리뷰 차트 모양이 지금 정도면 괜찮은지 확인 부탁드립니다.
