### PR TITLE
챗봇 - 챗봇 메시지 보더 색상 수정 (.defaultGradient → .accentGradient)

### DIFF
--- a/AIProject/AIProject/Features/ChatBot/View/BotMessageView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/BotMessageView.swift
@@ -53,7 +53,7 @@ struct BotMessageView: View {
             }
             .overlay {
                 UnevenRoundedRectangle(bottomLeadingRadius: 16, bottomTrailingRadius: 16, topTrailingRadius: 16)
-                    .strokeBorder(.defaultGradient, lineWidth: 0.5)
+                    .strokeBorder(.accentGradient, lineWidth: 0.5)
             }
             .frame(maxWidth: 300, alignment: .leading)
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #362 

## 📝 작업 내용

챗봇 메시지 보더 색상을 피그마와 맞게 `.defaultGradient` → `.accentGradient` 로 변경

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

없습니다