### PR TITLE
챗봇 - 다크모드 채팅 화면 배경 구분 수정

### DIFF
--- a/AIProject/AIProject/Features/ChatBot/View/ChatBotView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/ChatBotView.swift
@@ -43,7 +43,7 @@ struct ChatBotView: View {
                 .background(.aiCoBackground)
 
                 ChatInputView(viewModel: viewModel)
-                    .background(.aiCoBackgroundWhite)
+                    .background(.aiCoBackground)
             }
             .frame(maxWidth: .infinity)
             .background(

--- a/AIProject/AIProject/Features/ChatBot/View/ChatInputView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/ChatInputView.swift
@@ -46,6 +46,10 @@ struct ChatInputView: View {
         .padding(.leading, 17)
         .padding(.trailing, 14)
         .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 30)
+                .fill(Color.aiCoBackgroundWhite)
+        )
         .overlay {
             RoundedRectangle(cornerRadius: 30)
                 .strokeBorder(.defaultGradient, lineWidth: 0.5)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #365 

## 📝 작업 내용

- `ChatBotView`에서 `ChatInputView` 배경색을 `.aiCoBackground`로 통일
- `ChatInputView`에 `RoundedRectangle` 배경 (`Color.aiCoBackgroundWhite`) 적용

### 스크린샷 (선택)
- 다크모드 변경 전 / 후
<p align="center">  
<img src="https://github.com/user-attachments/assets/ab48e7e9-7a21-42f3-beff-29a19a40c170" width="32%">  
<img src="https://github.com/user-attachments/assets/97197c9a-9a2a-48c2-bcfb-770b28bba3f5" width="32%">  
</p>

- 라이트모드 변경 전 / 후
<p align="center">  
<img src="https://github.com/user-attachments/assets/1cb4c6a9-e006-4ea8-b1fb-d2eabe2d7c17" width="32%">  
<img src="https://github.com/user-attachments/assets/c231bd56-fa1f-457a-8090-a4e3a05120dd" width="32%">  
</p>

## 💬 리뷰 요구사항(선택)

없습니다!