### PR TITLE
AI 브리핑 없어도 북마크만 내보내기 활성화

### DIFF
--- a/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
@@ -151,8 +151,8 @@ struct BookmarkView: View {
                         RoundedButton(title: "전체 삭제", imageName: "trash") {
                             showDeleteConfirm = true
                         }
-                        .disabled(isExportDisabled)
-                        .opacity(isExportDisabled ? 0.6 : 1.0)
+                        .disabled(bookmarks.isEmpty)
+                        .opacity(bookmarks.isEmpty ? 0.6 : 1.0)
                         .alert("전체 북마크 삭제", isPresented: $showDeleteConfirm) {
                             Button("삭제", role: .destructive) {
                                 vm.deleteAllBookmarks()
@@ -179,12 +179,12 @@ struct BookmarkView: View {
                         // 북마크한 코인이 없을 시 내보내기 버튼 숨기기
                         if !bookmarks.isEmpty {
                             RoundedRectangleFillButton(title: "내보내기", imageName: "square.and.arrow.up", isHighlighted: .constant(false)) {
-                                guard !isExportDisabled else { return }
+                                guard !bookmarks.isEmpty else { return }
                                 showingExportOptions = true
                                 
                             }
-                            .disabled(isExportDisabled)
-                            .opacity(isExportDisabled ? 0.6 : 1.0)
+                            .disabled(bookmarks.isEmpty)
+                            .opacity(bookmarks.isEmpty ? 0.6 : 1.0)
                         }
                     }
                     .frame(maxWidth: .infinity)

--- a/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
@@ -303,7 +303,7 @@ struct ActivityView: UIViewControllerRepresentable {
 
 /// 내보내기 전용 뷰
 struct ExportReportView: View {
-    let dto: PortfolioBriefingDTO
+    let dto: PortfolioBriefingDTO?
     let coins: [BookmarkEntity]
     let imageURLProvider: (String) -> URL?
 
@@ -315,16 +315,18 @@ struct ExportReportView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             // 브리핑
-            BriefingSectionView(briefing: dto)
-                .padding(16)
-                .background(
-                    RoundedRectangle(cornerRadius: 20)
-                        .fill(Color.aiCoBackgroundAccent)
-                        .overlay(RoundedRectangle(cornerRadius: 20)
-                            .strokeBorder(.accentGradient, lineWidth: 0.5))
-                )
-                .cornerRadius(20)
-                .padding(.horizontal, 16)
+            if let dto {
+                BriefingSectionView(briefing: dto)
+                    .padding(16)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color.aiCoBackgroundAccent)
+                            .overlay(RoundedRectangle(cornerRadius: 20)
+                                .strokeBorder(.accentGradient, lineWidth: 0.5))
+                    )
+                    .cornerRadius(20)
+                    .padding(.horizontal, 16)
+            }
 
             CoinListSectionView(
                 sortedCoins: coins,

--- a/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
@@ -205,6 +205,7 @@ struct BookmarkView: View {
                 }
             }
             .task {
+                vm.cancelTask()
                 guard !bookmarks.isEmpty else {
                     vm.briefing = nil
                     vm.imageMap = [:]

--- a/AIProject/AIProject/Features/MyPage/ViewModel/BookmarkViewModel.swift
+++ b/AIProject/AIProject/Features/MyPage/ViewModel/BookmarkViewModel.swift
@@ -33,7 +33,6 @@ final class BookmarkViewModel: ObservableObject {
 
     func loadBriefing(character: RiskTolerance) async {
         do {
-            cancelTask()
             let bookmarks = try manager.fetchAll()
             print("북마크된 코인: ", bookmarks)
             guard !bookmarks.isEmpty else {

--- a/AIProject/AIProject/Features/MyPage/ViewModel/BookmarkViewModel.swift
+++ b/AIProject/AIProject/Features/MyPage/ViewModel/BookmarkViewModel.swift
@@ -132,8 +132,6 @@ final class BookmarkViewModel: ObservableObject {
 // MARK: - 북마크 내보내기 관련
     /// scale: 해상도 (2x, 레티나 해상도)
     func makeFullReportImage(scale: CGFloat = 2.0) -> UIImage? {
-        guard let dto = briefing else { return nil }
-
         let coins: [BookmarkEntity]
             do {
                 coins = try manager.fetchAll()
@@ -145,7 +143,7 @@ final class BookmarkViewModel: ObservableObject {
         let targetWidth = currentScreenWidth()
 
         let exportView = ExportReportView(
-            dto: dto, coins: coins, imageURLProvider: { [weak self] in self?.imageURL(for: $0) }
+            dto: briefing, coins: coins, imageURLProvider: { [weak self] in self?.imageURL(for: $0) }
         )
             .frame(width: targetWidth, alignment: .leading)
             .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>


## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 북마크만 비어있지 않다면 내보내기 버튼을 활성화 시켰습니다. -> exportReportView에서 BriefingSection 없어짐

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
