### PR TITLE
탭바 - iOS 17에서 미지원 SF Symbols 아이콘 분기 처리

### DIFF
--- a/AIProject/AIProject/Features/Main/TabFeature.swift
+++ b/AIProject/AIProject/Features/Main/TabFeature.swift
@@ -18,7 +18,11 @@ enum TabFeature: String, Hashable, CaseIterable, Identifiable {
         case .dashboard:
             return "square.grid.2x2"
         case .market:
-            return "bitcoinsign.bank.building"
+            if #available(iOS 18, *) {
+                   return "bitcoinsign.bank.building"
+               } else {
+                   return "bitcoinsign.circle"
+               }
         case .chatbot:
             return "bubble.left.and.text.bubble.right"
         case .myPage:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #436 

## 📝 작업 내용

- iOS 버전 분기 처리 추가
  - iOS 18 이상: `bitcoinsign.bank.building` 사용
    <img width="500" src="https://github.com/user-attachments/assets/a084957e-0f35-49fd-a250-3d2fc87b2736" />
  - iOS 17: 대체 아이콘 `bitcoinsign.circle` 사용
    <img width="500" src="https://github.com/user-attachments/assets/9193ad1e-8ff5-4448-8fdd-515cd5342a8a" />

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
