### PR TITLE
촐싹거리는 시세 레이블 이슈 

### DIFF
--- a/AIProject/AIProject/Domain/Model/Coin/TickerValue.swift
+++ b/AIProject/AIProject/Domain/Model/Coin/TickerValue.swift
@@ -27,3 +27,25 @@ extension TickerValue: Equatable {
         lhs.id == rhs.id && lhs.price == rhs.price && lhs.rate == rhs.rate
     }
 }
+
+extension TickerValue {
+    private var code: String {
+        switch change {
+        case .rise: return "▲"
+        case .even: return ""
+        case .fall: return "▼"
+        }
+    }
+    
+    var formatedRate: String {
+        code + rate.formatted(.percent.precision(.fractionLength(2)))
+    }
+    
+    var formatedPrice: String {
+        price.formatted(.number) + "원"
+    }
+    
+    var formatedVolume: String {
+        volume.formatMillion
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>

- close #439

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- ticker helper computed property
```swift
extension TickerValue {
    private var code: String {
        switch change {
        case .rise: return "▲"
        case .even: return ""
        case .fall: return "▼"
        }
    }
    /// ▲ 0.43% 
    var formatedRate: String {
        code + rate.formatted(.percent.precision(.fractionLength(2)))
    }
    
   /// 1,590,000원
    var formatedPrice: String {
        price.formatted(.number) + "원"
    }
    
   ///  2,390백만
    var formatedVolume: String {
        volume.formatMillion
    }
}
```
- 코인 시세 layout shifting 이슈

구현 아이디어
1. ZStack 안에 가격 string의 monospace + padding으로 가질 수 있는 가장 큰 크기의 넓이를 구한 후, 변수에 저장
2. 실제 보여질 priceString의 minWidth에 위에 구한 값 대입

### 스크린샷 (선택)
<table>
<tr><th>수정 전</th><th>수정 후</th></tr>
<tr><td>

https://github.com/user-attachments/assets/094dba38-c9a3-4a48-bd4f-d42d99f468f7

</td><td>

https://github.com/user-attachments/assets/48764091-2e6c-4200-90af-da0e6a4680f4

</td></tr>
</table>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

@kitcat-s 
조금 많이 늦었지만 TickerDTO를 TickerValue로 변경하시고, 위의 값을 사용하시면 됩니다!
