### PR TITLE
챗봇 -> 마이페이지 탭 화면 변경시에 레이아웃이 이상하게 뿌려지는 버그 수정

### DIFF
--- a/AIProject/AIProject/Features/Main/MainTabView.swift
+++ b/AIProject/AIProject/Features/Main/MainTabView.swift
@@ -31,6 +31,7 @@ struct MainTabView: View {
             }
         }
         .environment(router)
+        .transaction { $0.animation = nil }
     }
     
     @ViewBuilder func makeTab(_ tab: TabFeature) -> some View {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>

- #382 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) 

- 탭 화면 변경 레이아웃 버그 수정

`.transaction { $0.animation = nil }` 로 탭뷰 애니메이션 제거

**아래는 버그의 이유인데 완전히 신뢰는 하지 않는게 좋을거 같습니다!**

<img width="790" height="663" alt="image" src="https://github.com/user-attachments/assets/a155b02b-4827-41c7-b0e6-bdad6de872cc" />




## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
