### PR TITLE
서치 레코드 리프레쉬 제거, 키보드 자동완성 제거, 코인 심볼 검색

### DIFF
--- a/AIProject/AIProject/Features/Market/MarketStore.swift
+++ b/AIProject/AIProject/Features/Market/MarketStore.swift
@@ -152,7 +152,7 @@ extension MarketStore {
             metas = coinMeta.filter { bookmarkIDs.contains($0.key) }
         }
         
-        let text = searchText
+        let text = searchText.localizedLowercase
         
         let filteredCoinID: Set<CoinID>
         
@@ -161,7 +161,7 @@ extension MarketStore {
         } else {
             filteredCoinID = metas
                 .filter { key, value in
-                    value.koreanName.contains(text)
+                    value.koreanName.contains(text) || value.coinSymbol.localizedLowercase.contains(text)
                 }
                 .map(\.key)
                 .reduce(into: Set<CoinID>(), { acc, e in

--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -34,11 +34,12 @@ struct MarketView: View {
                 CoinListView(store: store, selectedCoinID: $selectedCoinID, searchText: $searchText)
                     .padding(.horizontal, 16)
                     .padding(.bottom, 16)
-            }
-            .refreshable {
-                Task {
-                    await store.refresh()
-                }
+                
+                    .refreshable {
+                        Task {
+                            await store.refresh()
+                        }
+                    }
             }
             .onChange(of: searchText, { oldValue, newValue in
                 Task {

--- a/AIProject/AIProject/Features/Market/SubView/BlinkUnderlineOnChange.swift
+++ b/AIProject/AIProject/Features/Market/SubView/BlinkUnderlineOnChange.swift
@@ -1,0 +1,70 @@
+//
+//  BlinkUnderlineOnChange.swift
+//  AIProject
+//
+//  Created by kangho lee on 8/29/25.
+//
+
+import SwiftUI
+
+struct BlinkUnderlineOnChange<Value: Equatable>: ViewModifier {
+    let trigger: Value
+    var duration: Duration = .seconds(2)
+    var color: Color = .aiCoLabel
+    var lineWidth: CGFloat = 2
+    
+    @State private var animating = false
+    @State private var hideTask: Task<Void, Never>?
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(color)
+                    .frame(height: 1.5)
+                    .padding(.leading, 8)
+                    .opacity(animating ? 1 : 0)
+                    .offset(y: 2)
+                    .animation(
+                        animating
+                        ? .easeIn(duration: 0.3)
+                            .repeatForever(autoreverses: true)
+                        : .default,
+                        value: animating
+                    )
+            }
+            .onChange(of: trigger) { _, _ in
+                start()
+            }
+            .onDisappear {
+                hideTask?.cancel()
+            }
+    }
+    
+    @MainActor
+    private func start() {
+        hideTask?.cancel()
+        animating = true
+        
+        hideTask = Task {
+            try? await Task.sleep(for: duration)
+            animating = false
+        }
+    }
+}
+
+extension View {
+    func blinkUnderlineOnChange<Value: Equatable>(
+        _ trigger: Value,
+        duration: Duration = .seconds(1),
+        color: Color = .aiCoLabel
+    ) -> some View {
+        modifier(
+            BlinkUnderlineOnChange(
+                trigger: trigger,
+                duration: duration,
+                color: color
+            )
+        )
+    }
+}

--- a/AIProject/AIProject/Features/Market/SubView/CoinCell.swift
+++ b/AIProject/AIProject/Features/Market/SubView/CoinCell.swift
@@ -51,7 +51,7 @@ fileprivate struct CoinMetaView: View {
                     .font(.system(size: name.count < 8 ? 14 : 12))
                     .fontWeight(.bold)
                 
-                Text(symbol)
+                Text(symbol.highlighted(searchTerm))
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
             }

--- a/AIProject/AIProject/Features/Market/SubView/CoinCell.swift
+++ b/AIProject/AIProject/Features/Market/SubView/CoinCell.swift
@@ -89,15 +89,16 @@ fileprivate struct CoinPriceView: View {
                 Text(ticker.snapshot.formatedPrice)
                     .frame(minWidth: priceWidth, alignment: .trailing)
                     .font(.system(size: 15))
-                    .background {
-                        GeometryReader { proxy in
-                            Rectangle()
-                                .fill(.clear)
-                                .frame(width: proxy.size.width - pricePadding, height: 1)
-                                .blinkBorderOnChange(ticker.snapshot.price, duration: .milliseconds(400), color: .aiCoLabel, lineWidth: 0.7, cornerRadius:0.5)
-                                .offset(x: pricePadding, y: proxy.size.height + 1)
-                        }
-                    }
+                    .blinkUnderlineOnChange(ticker.snapshot.price)
+//                .offset(y: proxy.size.height + 1)
+//                    .background {
+//                        GeometryReader { proxy in
+//                            Rectangle()
+//                                .fill(.clear)
+//                                .frame(width: proxy.size.width, height: 1)
+//                                
+//                        }
+//                    }
             }
             .frame(alignment: .trailing)
             
@@ -127,8 +128,10 @@ fileprivate struct CoinPriceView: View {
                         }
                 }
                 .monospacedDigit()
-                .opacity(0)
+                .hidden()
             }
+            .accessibilityHidden(true) // 최적화를 위해 사용
+            .allowsHitTesting(false)
         }
     }
 }

--- a/AIProject/AIProject/Features/Search/SearchBarView.swift
+++ b/AIProject/AIProject/Features/Search/SearchBarView.swift
@@ -19,7 +19,9 @@ struct SearchBarView: View {
                     .foregroundStyle(.aiCoLabel)
 
                 TextField("코인 이름으로 검색하세요", text: $searchText)
-                    .autocorrectionDisabled()
+                    .keyboardType(.webSearch)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
                     .padding(.horizontal, 8)
                     .submitLabel(.search)
                     .font(.system(size: 14))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

- close #414 
- close #467

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- 서치레코드의 상위뷰에 refreshable을 붙여서 vertical scroll 및 pull to refresh가 생기는 이슈 대응
- 대소문자 무시 / 자동완성 제거 / 코인심볼 검색 및 하이라이팅 적용

### 스크린샷 (선택)
<img width="40%" height="2622" alt="image" src="https://github.com/user-attachments/assets/65457c09-1ac6-4756-aaf9-a35b18732441" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

없습니다.
