### PR TITLE
대시보드 AI 브리핑 응답 글자 수가 길어지면서 UI 깨지는 현상 수정

### DIFF
--- a/AIProject/AIProject/Domain/Model/Common/Prompt.swift
+++ b/AIProject/AIProject/Domain/Model/Common/Prompt.swift
@@ -82,7 +82,7 @@ enum Prompt {
                 /// 주어진 시간 동안의 암호화폐 전체 시장 분위기 (호재 / 악재 / 중립)
                 let todaysSentiment: String
                 
-                /// 내용 요약
+                /// 내용 요약 (글자수 200자)
                 /// 호재의 경우 긍정요인만 or 악재라면 부정 요인만 제공
                 /// 중립이라면 긍정요인, 부정요인을 자연스럽게 연결한 문자열을 제공
                 let summary: String
@@ -101,7 +101,7 @@ enum Prompt {
             struct InsightDTO: Codable {
                 /// 게시물을 기반으로 평가한 커뮤니티 분위기 (호재 / 악재 / 중립)
                 let todaysSentiment: String
-                /// 커뮤니티 분위기를 그렇게 평가한 이유를 문자열로 요약
+                /// 커뮤니티 분위기를 그렇게 평가한 이유를 문자열로 요약 (글자수 200자)
                 let summary: String
             }
             

--- a/AIProject/AIProject/Domain/Model/Dashboard/HeightPreferenceKey.swift
+++ b/AIProject/AIProject/Domain/Model/Dashboard/HeightPreferenceKey.swift
@@ -1,0 +1,19 @@
+//
+//  HeightPreferenceKey.swift
+//  AIProject
+//
+//  Created by 장지현 on 8/30/25.
+//
+
+import SwiftUI
+
+/// 뷰의 높이를 측정하고 부모 뷰로 전달하기 위한 `PreferenceKey`입니다.
+///
+/// 여러 자식 뷰에서 보고된 높이 값 중 최대값을 유지하도록 동작합니다.
+/// 레이아웃 계산 시, 자식 뷰들의 높이를 비교하여 가장 큰 값을 부모 뷰에 전달하는 데 사용됩니다.
+struct HeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}

--- a/AIProject/AIProject/Features/Base/ReportSectionView.swift
+++ b/AIProject/AIProject/Features/Base/ReportSectionView.swift
@@ -72,24 +72,12 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
                         data.onCancel()
                     }
                 case .success(let value):
-                    ViewThatFits(in: .vertical) {
-                        content(value)
-                            .font(.system(size: 14))
-                            .foregroundStyle(.aiCoLabel)
-                            .lineSpacing(6)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(maxHeight: .infinity, alignment: .top)
-                        
-                        ScrollView {
-                            content(value)
-                                .font(.system(size: 14))
-                                .foregroundStyle(.aiCoLabel)
-                                .lineSpacing(6)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .padding(.trailing, 2)
-                        }
-                        .scrollIndicators(.hidden)
-                    }
+                    content(value)
+                        .font(.system(size: 14))
+                        .foregroundStyle(.aiCoLabel)
+                        .lineSpacing(6)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxHeight: .infinity, alignment: .top)
                     
                     if let ts = data.timestamp {
                         TimestampWithRefreshButtonView(timestamp: ts) {
@@ -115,11 +103,20 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
             RoundedRectangle(cornerRadius: cornerRadius)
                 .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
+        .background(
+            GeometryReader { geo in
+                Color.clear
+                    .preference(key: HeightPreferenceKey.self,
+                                value: geo.size.height)
+            }
+        )
     }
 }
 
 #Preview() {
-    VStack {
+    @Previewable @State var maxHeight: CGFloat = 0
+    
+    HStack {
         ReportSectionView(
             data: ReportSectionData<String>(
                 id: "success",
@@ -142,7 +139,7 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
                 Text(value)
             }
         )
-        .frame(height: 320)
+        .frame(height: maxHeight)
         
         ReportSectionView(
             data: ReportSectionData<String>(
@@ -166,7 +163,10 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
                 Text(value)
             }
         )
-        .frame(height: 320)
+        .frame(height: maxHeight)
     }
     .padding(.horizontal, 16)
+    .onPreferenceChange(HeightPreferenceKey.self) { value in
+        maxHeight = value
+    }
 }

--- a/AIProject/AIProject/Features/Base/ReportSectionView.swift
+++ b/AIProject/AIProject/Features/Base/ReportSectionView.swift
@@ -78,6 +78,7 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
                             .foregroundStyle(.aiCoLabel)
                             .lineSpacing(6)
                             .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxHeight: .infinity, alignment: .top)
                         
                         ScrollView {
                             content(value)
@@ -118,28 +119,54 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
 }
 
 #Preview() {
-    ReportSectionView(
-        data: ReportSectionData<String>(
-            id: "success",
-            icon: "chart.line.uptrend.xyaxis",
-            title: "시장 요약",
-            state: .success("리플(XRP)이 시카고상품거래소(CME)에서 미결제약정 10억 달러를 기록하며 가격이 폭등하고, 바이낸스에 대규모 스테이블코인이 유입되면서 암호화폐 시장에 반전 조짐이 나타나고 있습니다. 다만, 대형 고래들의 매각 활동으로 인해 시장이 갑작스러운 매도세로 돌아서면서 투자자들이 불안해하고 있으며, 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. "),
-            timestamp: Date(),
-            onCancel: {},
-            onRetry: {}
-        ),
-        trailing: { value in
-            Button(action: { UIPasteboard.general.string = value }) {
-                Image(systemName: "doc.on.doc")
-                    .font(.system(size: 14, weight: .semibold))
+    VStack {
+        ReportSectionView(
+            data: ReportSectionData<String>(
+                id: "success",
+                icon: "chart.line.uptrend.xyaxis",
+                title: "시장 요약",
+                state: .success("리플(XRP)이 시카고상품거래소(CME)에서 미결제약정 10억 달러를 기록하며 가격이 폭등하고, 바이낸스에 대규모 스테이블코인이 유입되면서 암호화폐 시장에 반전 조짐이 나타나고 있습니다."),
+                timestamp: Date(),
+                onCancel: {},
+                onRetry: {}
+            ),
+            trailing: { value in
+                Button(action: { UIPasteboard.general.string = value }) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("내용 복사")
+            },
+            content: { value in
+                Text(value)
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("내용 복사")
-        },
-        content: { value in
-            Text(value)
-        }
-    )
+        )
+        .frame(height: 320)
+        
+        ReportSectionView(
+            data: ReportSectionData<String>(
+                id: "success",
+                icon: "chart.line.uptrend.xyaxis",
+                title: "시장 요약",
+                state: .success("리플(XRP)이 시카고상품거래소(CME)에서 미결제약정 10억 달러를 기록하며 가격이 폭등하고, 바이낸스에 대규모 스테이블코인이 유입되면서 암호화폐 시장에 반전 조짐이 나타나고 있습니다. 다만, 대형 고래들의 매각 활동으로 인해 시장이 갑작스러운 매도세로 돌아서면서 투자자들이 불안해하고 있으며, 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. "),
+                timestamp: Date(),
+                onCancel: {},
+                onRetry: {}
+            ),
+            trailing: { value in
+                Button(action: { UIPasteboard.general.string = value }) {
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("내용 복사")
+            },
+            content: { value in
+                Text(value)
+            }
+        )
+        .frame(height: 320)
+    }
     .padding(.horizontal, 16)
-    .frame(height: 320)
 }

--- a/AIProject/AIProject/Features/Base/ReportSectionView.swift
+++ b/AIProject/AIProject/Features/Base/ReportSectionView.swift
@@ -21,7 +21,7 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
     let data: ReportSectionData<Value>
     @ViewBuilder var trailing: (Value) -> Trailing
     @ViewBuilder var content: (Value) -> Content
-
+    
     private let cornerRadius: CGFloat = 20
     
     // No-trailing initializer
@@ -33,7 +33,7 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
         self.trailing = { _ in EmptyView() }
         self.content = content
     }
-
+    
     // Trailing initializer
     init(
         data: ReportSectionData<Value>,
@@ -44,7 +44,7 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
         self.trailing = trailing
         self.content = content
     }
-
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             // Header
@@ -52,18 +52,18 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
                 Image(systemName: data.icon)
                     .font(.system(size: 14, weight: .bold))
                     .foregroundStyle(.aiCoAccent)
-
+                
                 Text(data.title)
                     .font(.system(size: 16, weight: .bold))
                     .foregroundStyle(.aiCoLabel)
-
+                
                 Spacer()
-
+                
                 if case let .success(value) = data.state {
                     trailing(value)
                 }
             }
-
+            
             // Content
             Group {
                 switch data.state {
@@ -72,12 +72,23 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
                         data.onCancel()
                     }
                 case .success(let value):
-                    content(value)
-                        .font(.system(size: 14))
-                        .foregroundStyle(.aiCoLabel)
-                        .lineSpacing(6)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxHeight: .infinity, alignment: .top)
+                    ViewThatFits(in: .vertical) {
+                        content(value)
+                            .font(.system(size: 14))
+                            .foregroundStyle(.aiCoLabel)
+                            .lineSpacing(6)
+                            .fixedSize(horizontal: false, vertical: true)
+                        
+                        ScrollView {
+                            content(value)
+                                .font(.system(size: 14))
+                                .foregroundStyle(.aiCoLabel)
+                                .lineSpacing(6)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(.trailing, 2)
+                        }
+                        .scrollIndicators(.hidden)
+                    }
                     
                     if let ts = data.timestamp {
                         TimestampWithRefreshButtonView(timestamp: ts) {
@@ -104,4 +115,31 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
                 .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
     }
+}
+
+#Preview() {
+    ReportSectionView(
+        data: ReportSectionData<String>(
+            id: "success",
+            icon: "chart.line.uptrend.xyaxis",
+            title: "시장 요약",
+            state: .success("리플(XRP)이 시카고상품거래소(CME)에서 미결제약정 10억 달러를 기록하며 가격이 폭등하고, 바이낸스에 대규모 스테이블코인이 유입되면서 암호화폐 시장에 반전 조짐이 나타나고 있습니다. 다만, 대형 고래들의 매각 활동으로 인해 시장이 갑작스러운 매도세로 돌아서면서 투자자들이 불안해하고 있으며, 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. "),
+            timestamp: Date(),
+            onCancel: {},
+            onRetry: {}
+        ),
+        trailing: { value in
+            Button(action: { UIPasteboard.general.string = value }) {
+                Image(systemName: "doc.on.doc")
+                    .font(.system(size: 14, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("내용 복사")
+        },
+        content: { value in
+            Text(value)
+        }
+    )
+    .padding(.horizontal, 16)
+    .frame(height: 320)
 }

--- a/AIProject/AIProject/Features/Base/ReportSectionView.swift
+++ b/AIProject/AIProject/Features/Base/ReportSectionView.swift
@@ -113,57 +113,116 @@ struct ReportSectionView<Value, Trailing: View, Content: View>: View {
     }
 }
 
-#Preview() {
+#Preview("둘 중 더 큰 높이로 적용") {
+    @Previewable @Environment(\.horizontalSizeClass) var hSizeClass
     @Previewable @State var maxHeight: CGFloat = 0
     
-    HStack {
-        ReportSectionView(
-            data: ReportSectionData<String>(
-                id: "success",
-                icon: "chart.line.uptrend.xyaxis",
-                title: "시장 요약",
-                state: .success("리플(XRP)이 시카고상품거래소(CME)에서 미결제약정 10억 달러를 기록하며 가격이 폭등하고, 바이낸스에 대규모 스테이블코인이 유입되면서 암호화폐 시장에 반전 조짐이 나타나고 있습니다."),
-                timestamp: Date(),
-                onCancel: {},
-                onRetry: {}
-            ),
-            trailing: { value in
-                Button(action: { UIPasteboard.general.string = value }) {
-                    Image(systemName: "doc.on.doc")
-                        .font(.system(size: 14, weight: .semibold))
+    ScrollView {
+        let content = Group {
+            ReportSectionView(
+                data: ReportSectionData<String>(
+                    id: "success",
+                    icon: "chart.line.uptrend.xyaxis",
+                    title: "시장 요약",
+                    state: .success("짧은 글"),
+                    timestamp: Date(),
+                    onCancel: {},
+                    onRetry: {}
+                ),
+                trailing: { value in
+                    Button(action: { UIPasteboard.general.string = value }) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("내용 복사")
+                },
+                content: { value in
+                    Text(value)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("내용 복사")
-            },
-            content: { value in
-                Text(value)
-            }
-        )
-        .frame(height: maxHeight)
+            )
+            .frame(height: max(maxHeight, 250))
+            
+            ReportSectionView(
+                data: ReportSectionData<String>(
+                    id: "success",
+                    icon: "chart.line.uptrend.xyaxis",
+                    title: "시장 요약",
+                    state: .success("긴 글. 리플(XRP)이 시카고상품거래소(CME)에서 미결제약정 10억 달러를 기록하며 가격이 폭등하고, 바이낸스에 대규모 스테이블코인이 유입되면서 암호화폐 시장에 반전 조짐이 나타나고 있습니다. 다만, 대형 고래들의 매각 활동으로 인해 시장이 갑작스러운 매도세로 돌아서면서 투자자들이 불안해하고 있으며, 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 리플(XRP)이 시카고상품거래소(CME)에서 미결제약정 10억 달러를 기록하며 가격이 폭등하고, 바이낸스에 대규모 스테이블코인이 유입되면서 암호화폐 시장에 반전 조짐이 나타나고 있습니다. 다만, 대형 고래들의 매각 활동으로 인해 시장이 갑작스러운 매도세로 돌아서면서 투자자들이 불안해하고 있으며, 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다."),
+                    timestamp: Date(),
+                    onCancel: {},
+                    onRetry: {}
+                ),
+                trailing: { value in
+                    Button(action: { UIPasteboard.general.string = value }) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("내용 복사")
+                },
+                content: { value in
+                    Text(value)
+                }
+            )
+            .frame(height: max(maxHeight, 250))
+        }
         
-        ReportSectionView(
-            data: ReportSectionData<String>(
-                id: "success",
-                icon: "chart.line.uptrend.xyaxis",
-                title: "시장 요약",
-                state: .success("리플(XRP)이 시카고상품거래소(CME)에서 미결제약정 10억 달러를 기록하며 가격이 폭등하고, 바이낸스에 대규모 스테이블코인이 유입되면서 암호화폐 시장에 반전 조짐이 나타나고 있습니다. 다만, 대형 고래들의 매각 활동으로 인해 시장이 갑작스러운 매도세로 돌아서면서 투자자들이 불안해하고 있으며, 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. 비트코인이 11만 달러 저지선을 이탈하며 공포가 확산되고 있습니다. "),
-                timestamp: Date(),
-                onCancel: {},
-                onRetry: {}
-            ),
-            trailing: { value in
-                Button(action: { UIPasteboard.general.string = value }) {
-                    Image(systemName: "doc.on.doc")
-                        .font(.system(size: 14, weight: .semibold))
+        if hSizeClass == .regular {
+            HStack { content }
+        } else {
+            VStack { content }
+        }
+        
+    }
+    .padding(.horizontal, 16)
+    .onPreferenceChange(HeightPreferenceKey.self) { value in
+        maxHeight = value
+    }
+}
+
+#Preview("최소 높이 적용") {
+    @Previewable @Environment(\.horizontalSizeClass) var hSizeClass
+    @Previewable @State var maxHeight: CGFloat = 0
+    
+    ScrollView {
+        let content = ReportSectionView(
+                data: ReportSectionData<String>(
+                    id: "success",
+                    icon: "chart.line.uptrend.xyaxis",
+                    title: "시장 요약",
+                    state: .success("짧은 글"),
+                    timestamp: Date(),
+                    onCancel: {},
+                    onRetry: {}
+                ),
+                trailing: { value in
+                    Button(action: { UIPasteboard.general.string = value }) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("내용 복사")
+                },
+                content: { value in
+                    Text(value)
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("내용 복사")
-            },
-            content: { value in
-                Text(value)
+            )
+            .frame(height: max(maxHeight, 250))
+        
+        
+        if hSizeClass == .regular {
+            HStack {
+                content
+                content
             }
-        )
-        .frame(height: maxHeight)
+        } else {
+            VStack {
+                content
+                content
+            }
+        }
+        
     }
     .padding(.horizontal, 16)
     .onPreferenceChange(HeightPreferenceKey.self) { value in

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -15,6 +15,7 @@ struct AIBriefingView: View {
     @Environment(\.verticalSizeClass) var vSizeClass
     @EnvironmentObject var themeManager: ThemeManager
     @StateObject private var viewModel: InsightViewModel
+    @State private var maxHeight: CGFloat = 0
     
     private var isPadLayout: Bool {
         hSizeClass == .regular && vSizeClass == .regular
@@ -39,8 +40,16 @@ struct AIBriefingView: View {
                     HStack(spacing: 16) {
                         briefingView
                     }
+                    .onPreferenceChange(HeightPreferenceKey.self) { value in
+                        maxHeight = value
+                    }
                 } else {
-                    briefingView
+                    VStack(spacing: 16) {
+                        briefingView
+                    }
+                    .onPreferenceChange(HeightPreferenceKey.self) { value in
+                        maxHeight = value
+                    }
                 }
                 
                 FearGreedView()
@@ -62,7 +71,7 @@ struct AIBriefingView: View {
                 },
                 content: { Text($0.summary.byCharWrapping) }
             )
-            .frame(height: 280)
+            .frame(height: maxHeight)
         }
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -62,7 +62,7 @@ struct AIBriefingView: View {
                 },
                 content: { Text($0.summary.byCharWrapping) }
             )
-            .frame(height: 280)
+            .frame(height: 320)
         }
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -62,7 +62,7 @@ struct AIBriefingView: View {
                 },
                 content: { Text($0.summary.byCharWrapping) }
             )
-            .frame(height: 320)
+            .frame(height: 280)
         }
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/AIBriefingView.swift
@@ -71,7 +71,7 @@ struct AIBriefingView: View {
                 },
                 content: { Text($0.summary.byCharWrapping) }
             )
-            .frame(height: maxHeight)
+            .frame(height: max(maxHeight, 250))
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 
- close #471

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 대시보드에서 앨런의 응답 글자수가 일정하지 않은데, 두 섹션의 길이가 다르면 아이패드에서 UI가 안정적이지 않아서 frame을 고정시켜뒀었습니다.
- ~~글자수가 길어지면 UI가 깨지는 걸 발견하고, 길어지면 내부에서 스크롤되도록 수정했습니다 (+ promt에 글자수 제한 추가)~~
- 스크롤 + 스크롤을 지양하고, PreferenceKey를 통해 section의 높이가 더 큰 값으로 height를 고정하도록 수정

### 스크린샷 (선택)
<table>
<tr>
<th>전</th>
<th>후</th>
</tr>
<tr>
<td>
<img width="603" height="870" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-30 at 15 45 49" src="https://github.com/user-attachments/assets/8bd9a7c8-7c75-4663-a15a-f9017c4efe24" />


</td>
<td>

https://github.com/user-attachments/assets/aa76daa4-99aa-4b9a-9438-9446ae14f942

<img width="403" height="874" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-30 at 17 36 50" src="https://github.com/user-attachments/assets/e932234b-72ed-4d07-acca-1f610c7bee8d" />


</td>
</tr>
</table>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
