### PR TITLE
기기 방향 전환 시 스크롤 위치 보정

### DIFF
--- a/AIProject/AIProject/Features/Dashboard/CardConst.swift
+++ b/AIProject/AIProject/Features/Dashboard/CardConst.swift
@@ -13,4 +13,6 @@ enum CardConst {
     static let headerHeight: CGFloat = 160
     static let headerContentSpacing: CGFloat = 30
     static let cardInnerPadding: CGFloat = 16
+    static let animationDuration: UInt64 = 50_000_000
+    static let animationDurationDouble: Double = Double(animationDuration) / 100_000_000
 }

--- a/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
@@ -99,10 +99,20 @@ struct CoinCarouselView: View {
             handleAutoScrolling(cardID: cardID)
         }
         .onChange(of: cardID ?? recommendedCoins.count) { _, newValue in
-            guard !recommendedCoins.isEmpty else { return }
-            
             // 수동 스크롤일 경우
+            guard !recommendedCoins.isEmpty else { return }
             handleManualScrolling(cardID: newValue)
+        }
+        .onChange(of: hSizeClass) { _, _ in
+            // 화면 회전 시 스크롤 위치 재조정
+            if let currentID = cardID {
+                // 애니메이션 없이 즉시 위치 재설정
+                cardID = nil
+                Task {
+                    try? await Task.sleep(nanoseconds: 10_000_000)
+                    cardID = currentID
+                }
+            }
         }
         .sheet(item: $selectedCoin) { coin in
             NavigationStack {

--- a/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
@@ -111,7 +111,7 @@ struct CoinCarouselView: View {
                 cardID = nil
                 Task {
                     try? await Task.sleep(nanoseconds: CardConst.animationDuration)
-                    cardID = currentID
+                    jump(to: currentID)
                 }
             }
         }
@@ -162,7 +162,13 @@ struct CoinCarouselView: View {
 }
 
 extension CoinCarouselView {
-    func handleAutoScrolling(cardID: Int) {
+    /// 캐러셀 스크롤 위치를 변경시키는 함수
+    private func jump(to nextCardID: Int) {
+        print(cardID)
+        self.cardID = nextCardID
+    }
+    
+    private func handleAutoScrolling(cardID: Int) {
         /// 코인 리스트의 배열의 index
         ///
         /// 0: 첫번째
@@ -178,13 +184,13 @@ extension CoinCarouselView {
             /// - 10 -> 5으로 순간 이동 + 5 -> 6으로 자연스럽게 순환
             wrappedCoins.removeFirst()
             wrappedCoins.append(recommendedCoins)
-            self.cardID = cardID - totalCoinCount // 10 -> 5로 빛보다 빠르게 바꿔치기
+            jump(to: cardID - totalCoinCount) // 10 -> 5로 빛보다 빠르게 바꿔치기
             
             Task {
                 try? await Task.sleep(nanoseconds: CardConst.animationDuration) // 5 -> 6으로 애니메이션과 함께 순환하기
                 withAnimation(.easeInOut(duration: CardConst.animationDurationDouble)) {
                     if let cardID = self.cardID {
-                        self.cardID = (cardID + 1) % (totalCoinCount * 3)
+                        jump(to: (cardID + 1) % (totalCoinCount * 3))
                     }
                 }
             }
@@ -192,25 +198,25 @@ extension CoinCarouselView {
         default:
             /// 기본적인 자동 스크롤 처리
             withAnimation(.easeInOut(duration: CardConst.animationDurationDouble)) {
-                self.cardID = (cardID + 1) % (totalCoinCount * 3)
+                jump(to: (cardID + 1) % (totalCoinCount * 3))
             }
         }
     }
     
-    func handleManualScrolling(cardID: Int) {
+    private func handleManualScrolling(cardID: Int) {
         // 중간 배열 밖으로 넘어갈 경우 중간 배열의 카드로 강제 점프시키기
         if cardID > totalCoinCount * 2 {
             isManualScrolling = true
             Task {
                 try await Task.sleep(nanoseconds: CardConst.animationDuration)
-                self.cardID = cardID - totalCoinCount
+                jump(to: cardID - totalCoinCount)
                 isManualScrolling = false
             }
         } else if cardID >= 0 && cardID < totalCoinCount {
             isManualScrolling = true
             Task {
                 try await Task.sleep(nanoseconds: CardConst.animationDuration)
-                self.cardID = cardID + totalCoinCount
+                jump(to: cardID + totalCoinCount)
                 isManualScrolling = false
             }
         }

--- a/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
@@ -33,6 +33,7 @@ struct CoinCarouselView: View {
     @State private var isManualScrolling = false
     /// viewModel에서 받아온 코인의 배열
     private var recommendedCoins: [RecommendCoin] { viewModel.recommendCoins }
+    private var totalCoinCount: Int { viewModel.numberOfCoins }
     /// 코인의 배열을 무한 스크롤시키기 위해 3번 반복해 저장하는 상태 변수
     @State var wrappedCoins = [[RecommendCoin]]()
     /// 카드 선택 시 코인의 상세 페이지로 이동시키기 위해 사용하는 상태 변수
@@ -98,7 +99,7 @@ struct CoinCarouselView: View {
             
             handleAutoScrolling(cardID: cardID)
         }
-        .onChange(of: cardID ?? recommendedCoins.count) { _, newValue in
+        .onChange(of: cardID ?? totalCoinCount) { _, newValue in
             // 수동 스크롤일 경우
             guard !recommendedCoins.isEmpty else { return }
             handleManualScrolling(cardID: newValue)
@@ -140,7 +141,7 @@ struct CoinCarouselView: View {
         .onAppear {
             // 무한 스크롤링 효과를 구현하기 위해 추천 코인 배열의 앞 뒤에 안전 코인을 붙이기
             wrappedCoins = [recommendedCoins, recommendedCoins, recommendedCoins]
-            cardID = recommendedCoins.count // 시작점을 중간 배열의 첫 번째 카드로 지정하기
+            cardID = totalCoinCount // 시작점을 중간 배열의 첫 번째 카드로 지정하기
             viewModel.startTimer()
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -162,8 +163,6 @@ struct CoinCarouselView: View {
 
 extension CoinCarouselView {
     func handleAutoScrolling(cardID: Int) {
-        let totalCoinCount = recommendedCoins.count
-        
         /// 코인 리스트의 배열의 index
         ///
         /// 0: 첫번째
@@ -199,21 +198,19 @@ extension CoinCarouselView {
     }
     
     func handleManualScrolling(cardID: Int) {
-        let totalCoins = recommendedCoins.count
-        
         // 중간 배열 밖으로 넘어갈 경우 중간 배열의 카드로 강제 점프시키기
-        if cardID > totalCoins * 2 {
+        if cardID > totalCoinCount * 2 {
             isManualScrolling = true
             Task {
                 try await Task.sleep(nanoseconds: 50_000_000)
-                self.cardID = cardID - totalCoins
+                self.cardID = cardID - totalCoinCount
                 isManualScrolling = false
             }
-        } else if cardID > 0 && cardID < totalCoins {
+        } else if cardID > 0 && cardID < totalCoinCount {
             isManualScrolling = true
             Task {
                 try await Task.sleep(nanoseconds: 50_000_000)
-                self.cardID = cardID + totalCoins
+                self.cardID = cardID + totalCoinCount
                 isManualScrolling = false
             }
         }

--- a/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
@@ -29,8 +29,8 @@ struct CoinCarouselView: View {
     /// 현재 추천 코인 카드의 인덱스를 저장하며,
     /// 선택된 카드의 위치를 추적하고 스크롤 포지션을 관리하는 데 사용하는 상태 변수
     @State var cardID: Int?
-    /// 수동 스크롤 방식으로 cardID를 변경 중인지 추적
-    @State private var isManualScrolling = false
+    /// 기기 방향 전환 중인지 추적
+    @State private var isChangingDirection = false
     /// viewModel에서 받아온 코인의 배열
     private var recommendedCoins: [RecommendCoin] { viewModel.recommendCoins }
     private var totalCoinCount: Int { viewModel.numberOfCoins }
@@ -90,6 +90,14 @@ struct CoinCarouselView: View {
                 viewModel.startTimer()
             })
         )
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            // 화면 회전 시 - 스크롤 위치 보정
+            isChangingDirection = true
+            if let currentID = cardID {
+                handleOrientationChange(currentID: currentID)
+                isChangingDirection = false
+            }
+        }
         .onReceive(viewModel.timer) { _ in
             // 자동 스크롤일 경우 - 타이머를 구독해 UI 업데이트하기
             guard !isDragging,
@@ -101,19 +109,10 @@ struct CoinCarouselView: View {
         }
         .onChange(of: cardID ?? totalCoinCount) { _, newValue in
             // 수동 스크롤일 경우
-            guard !recommendedCoins.isEmpty else { return }
+            guard !recommendedCoins.isEmpty,
+                  !isChangingDirection
+            else { return }
             handleManualScrolling(cardID: newValue)
-        }
-        .onChange(of: hSizeClass) { _, _ in
-            // 화면 회전 시 스크롤 위치 재조정
-            if let currentID = cardID {
-                // 애니메이션 없이 즉시 위치 재설정
-                cardID = nil
-                Task {
-                    try? await Task.sleep(nanoseconds: CardConst.animationDuration)
-                    jump(to: currentID)
-                }
-            }
         }
         .sheet(item: $selectedCoin) { coin in
             NavigationStack {
@@ -164,7 +163,6 @@ struct CoinCarouselView: View {
 extension CoinCarouselView {
     /// 캐러셀 스크롤 위치를 변경시키는 함수
     private func jump(to nextCardID: Int) {
-        print(cardID)
         self.cardID = nextCardID
     }
     
@@ -206,19 +204,26 @@ extension CoinCarouselView {
     private func handleManualScrolling(cardID: Int) {
         // 중간 배열 밖으로 넘어갈 경우 중간 배열의 카드로 강제 점프시키기
         if cardID > totalCoinCount * 2 {
-            isManualScrolling = true
             Task {
                 try await Task.sleep(nanoseconds: CardConst.animationDuration)
                 jump(to: cardID - totalCoinCount)
-                isManualScrolling = false
             }
         } else if cardID >= 0 && cardID < totalCoinCount {
-            isManualScrolling = true
             Task {
                 try await Task.sleep(nanoseconds: CardConst.animationDuration)
                 jump(to: cardID + totalCoinCount)
-                isManualScrolling = false
             }
+        }
+    }
+    
+    private func handleOrientationChange(currentID: Int) {
+        viewModel.stopTimer()
+        cardID = nil
+        // 애니메이션 없이 즉시 위치 재설정
+        Task {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            jump(to: currentID)
+            viewModel.startTimer()
         }
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
@@ -110,7 +110,7 @@ struct CoinCarouselView: View {
                 // 애니메이션 없이 즉시 위치 재설정
                 cardID = nil
                 Task {
-                    try? await Task.sleep(nanoseconds: 10_000_000)
+                    try? await Task.sleep(nanoseconds: CardConst.animationDuration)
                     cardID = currentID
                 }
             }
@@ -181,8 +181,8 @@ extension CoinCarouselView {
             self.cardID = cardID - totalCoinCount // 10 -> 5로 빛보다 빠르게 바꿔치기
             
             Task {
-                try? await Task.sleep(nanoseconds: 50_000_000) // 5 -> 6으로 애니메이션과 함께 순환하기
-                withAnimation(.easeInOut(duration: 0.5)) {
+                try? await Task.sleep(nanoseconds: CardConst.animationDuration) // 5 -> 6으로 애니메이션과 함께 순환하기
+                withAnimation(.easeInOut(duration: CardConst.animationDurationDouble)) {
                     if let cardID = self.cardID {
                         self.cardID = (cardID + 1) % (totalCoinCount * 3)
                     }
@@ -191,7 +191,7 @@ extension CoinCarouselView {
             return
         default:
             /// 기본적인 자동 스크롤 처리
-            withAnimation(.easeInOut(duration: 0.5)) {
+            withAnimation(.easeInOut(duration: CardConst.animationDurationDouble)) {
                 self.cardID = (cardID + 1) % (totalCoinCount * 3)
             }
         }
@@ -202,14 +202,14 @@ extension CoinCarouselView {
         if cardID > totalCoinCount * 2 {
             isManualScrolling = true
             Task {
-                try await Task.sleep(nanoseconds: 50_000_000)
+                try await Task.sleep(nanoseconds: CardConst.animationDuration)
                 self.cardID = cardID - totalCoinCount
                 isManualScrolling = false
             }
-        } else if cardID > 0 && cardID < totalCoinCount {
+        } else if cardID >= 0 && cardID < totalCoinCount {
             isManualScrolling = true
             Task {
-                try await Task.sleep(nanoseconds: 50_000_000)
+                try await Task.sleep(nanoseconds: CardConst.animationDuration)
                 self.cardID = cardID + totalCoinCount
                 isManualScrolling = false
             }

--- a/AIProject/AIProject/Features/Dashboard/ViewModel/RecommendCoinViewModel.swift
+++ b/AIProject/AIProject/Features/Dashboard/ViewModel/RecommendCoinViewModel.swift
@@ -19,6 +19,7 @@ final class RecommendCoinViewModel: ObservableObject {
     private var upbitService: UpBitApiServiceProtocol
 
     var task: Task<Void, Never>?
+    let numberOfCoins: Int = 5
 
     @Published var timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
     
@@ -130,7 +131,7 @@ final class RecommendCoinViewModel: ObservableObject {
                 if let coin = coin {
                     results.append(coin)
 
-                    if results.count == 5 {
+                    if results.count == numberOfCoins {
                         group.cancelAll()
                         break
                     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

- close #360 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- 기기 방향 전환 시 스크롤 위치 보정
- 각종 코드 리팩토링

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

현재 카드의 크기를 화면 크기에 따라 동적으로 조절하고 있습니다.

이 때 기기 방향 전환되면 화면 크기가 변경되면서 카드의 크기도 변경되는데
이때 스크롤의 위치가 변하는 이슈가 있습니다.

>   예
>         마지막 스크롤 위치 = 6,
>         방향 전환 후 = 8
>         자동 순환 작동 후 = 7

화면 크기가 변경되더라도 스크롤이 마지막에 저장된 카드로 보정되도록
nil로 변경 후 재설정하도록 했는데
이 과정에서 스크롤의 위치가 변경되며 불필요한 스크롤 애니메이션이 추가됩니다.

  

> 예
>         마지막 스크롤 위치 = 6,
>         방향 전환 후 = nil
>         카드 보정 후 = 6
>         자동 순환 작동 후 = 7

2시간 정도 고민해보고 nil로 변경하는 것 이외의 다른 방법으로 시도해봤는데 더 개선되는 것 같지 않아서
일단 현재 상태로 두려고 합니다!