### PR TITLE
refactor: HeaderView 멍청하게 만들기 및 분리

### DIFF
--- a/AIProject/AIProject/Data/API/Upbit/DefaultCoinService.swift
+++ b/AIProject/AIProject/Data/API/Upbit/DefaultCoinService.swift
@@ -1,0 +1,31 @@
+//
+//  DefaultCoinService.swift
+//  AIProject
+//
+//  Created by kangho lee on 8/30/25.
+//
+
+import Foundation
+
+final class DefaultCoinService: CoinService {
+    private let network: NetworkClient
+    private let endpoint: String = "https://api.upbit.com/v1"
+    
+    init(network: NetworkClient) {
+        self.network = network
+    }
+    
+    func meta() async throws -> [Coin] {
+        let urlString = "\(endpoint)/market/all"
+        guard let url = URL(string: urlString) else { throw NetworkError.invalidURL }
+        let coinDTOs: [CoinDTO] = try await network.request(url: url)
+        
+        return coinDTOs
+            .filter {
+                $0.coinID.contains("KRW")
+            }
+            .map {
+                Coin(id: $0.coinID, koreanName: $0.koreanName)
+            }
+    }
+}

--- a/AIProject/AIProject/Domain/Service/Coin/CoinStore.swift
+++ b/AIProject/AIProject/Domain/Service/Coin/CoinStore.swift
@@ -1,0 +1,34 @@
+//
+//  CoinStore.swift
+//  AIProject
+//
+//  Created by kangho lee on 8/30/25.
+//
+
+import Foundation
+
+protocol CoinService {
+    func meta() async throws -> [Coin]
+}
+
+@Observable
+final class CoinStore {
+    private let coinService: CoinService
+    
+    var coins: [CoinID: Coin] = [:]
+    
+    init(coinService: CoinService) {
+        self.coinService = coinService
+    }
+    
+    func loadCoins() async {
+        do {
+            coins = try await coinService.meta()
+                .reduce(into: [CoinID: Coin]()) {
+                    $0[$1.id] = $1
+                }
+        } catch {
+            coins = [:]
+        }
+    }
+}

--- a/AIProject/AIProject/Features/Base/HeaderView.swift
+++ b/AIProject/AIProject/Features/Base/HeaderView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 /// 마켓이나 북마크 메뉴일 경우 각 파라메터에 true 값을 넣어주세요.
 struct HeaderView: View {
     @Environment(\.horizontalSizeClass) var hSizeClass
+    @Environment(\.dismiss) var dismiss
     
     let heading: String
     let coinSymbol: String?
@@ -33,11 +34,11 @@ struct HeaderView: View {
     }
     
     var body: some View {
-        let isBigScreen = hSizeClass == .regular
         
         ZStack(alignment: .leading) {
-            if !isBigScreen && showBackButton {
+            if showBackButton {
                 Button {
+                    dismiss()
                     onBackButtonTap()
                 } label: {
                     Image(systemName: "chevron.backward")

--- a/AIProject/AIProject/Features/Base/HeaderView.swift
+++ b/AIProject/AIProject/Features/Base/HeaderView.swift
@@ -53,6 +53,10 @@ struct HeaderView: View {
             
             HStack {
                 HStack(alignment: .center, spacing: 8) {
+                    if let coinSymbol {
+                        CoinView(symbol: "\(coinSymbol)", size: 30)
+                    }
+                    
                     Text(heading)
                         .font(.system(size: 24, weight: .black))
                         .foregroundStyle(headingColor)
@@ -67,20 +71,6 @@ struct HeaderView: View {
                 .frame(maxWidth: showBackButton ? .infinity : nil)
                 
                 Spacer()
-                
-                if showSearchButton {
-                    Button {
-                        onSearchTap()
-                    } label: {
-                        Image(systemName: "magnifyingglass")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 24)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.aiCoLabel)
-                    }
-                }
-                    
             }
         }
         .padding(.horizontal, 16)

--- a/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/AIProject/Features/CoinDetail/View/CoinDetailView.swift
@@ -19,13 +19,9 @@ struct CoinDetailView: View {
     @State private var keyboardObserver: NSObjectProtocol?
     
     let coin: Coin
-    let onDismiss: (() -> Void)?
-    let isDashboard: Bool
     
-    init(coin: Coin, onDismiss: (() -> Void)? = nil, isDashboard: Bool = false) {
+    init(coin: Coin) {
         self.coin = coin
-        self.onDismiss = onDismiss
-        self.isDashboard = isDashboard
         _reportViewModel = StateObject(wrappedValue: ReportViewModel(coin: coin))
     }
     
@@ -37,18 +33,6 @@ struct CoinDetailView: View {
                 ScrollView {
                     VStack(spacing: 0) {
                         // 헤더
-                        if !isDashboard {
-                            HeaderView(
-                                heading: coin.koreanName,
-                                coinSymbol: coin.coinSymbol,
-                                showBackButton: true) {
-                                    if let onDismiss = onDismiss {
-                                        onDismiss()
-                                    } else {
-                                        dismiss()
-                                    }
-                                }
-                        }
                         
                         VStack(spacing: 16) {
                             tabButtons
@@ -84,15 +68,15 @@ struct CoinDetailView: View {
                 }
                 .scrollIndicators(.hidden)
             }
-            
-            if !isDashboard {
-                SafeAreaBackgroundView()
-            }
+//            
+//            if !isDashboard {
+//                SafeAreaBackgroundView()
+//            }
         }
         .onDisappear {
             reportViewModel.cancelAll()
         }
-        .toolbar(isDashboard ? .visible : .hidden, for: .navigationBar)
+//        .toolbar(isDashboard ? .visible : .hidden, for: .navigationBar)
         .interactiveSwipeBackEnabled()
     }
 }

--- a/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/AIProject/Features/Dashboard/View/CoinCarouselView.swift
@@ -105,26 +105,24 @@ struct CoinCarouselView: View {
             handleManualScrolling(cardID: newValue)
         }
         .sheet(item: $selectedCoin) { coin in
-            NavigationStack {
-                CoinDetailView(coin: Coin(id: "KRW-" + coin.id, koreanName: coin.name, imageURL: coin.imageURL), isDashboard: true)
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: .principal) {
-                            HStack(spacing: 8) {
-                                Text(coin.name)
-                                    .font(.system(size: 16, weight: .bold))
-                                    .foregroundStyle(.aiCoLabel)
-                                Text(coin.id)
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.aiCoLabelSecondary)
-                            }
-                        }
-                        ToolbarItem(placement: .topBarTrailing) {
-                            RoundedButton(imageName: "xmark") {
-                                selectedCoin = nil
-                            }
-                        }
+            
+            VStack(spacing: 0) {
+                ZStack(alignment: .center) {
+                    HeaderView(
+                        heading: coin.name,
+                        coinSymbol: coin.id,
+                        showBackButton: false
+                    )
+                    .toolbar(.hidden, for: .navigationBar)
+                    
+                    RoundedButton(imageName: "xmark") {
+                        selectedCoin = nil
                     }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .padding()
+                }
+                
+                CoinDetailView(coin: Coin(id: "KRW-" + coin.id, koreanName: coin.name, imageURL: coin.imageURL))
             }
         }
         .onAppear {

--- a/AIProject/AIProject/Features/Market/MarketView.swift
+++ b/AIProject/AIProject/Features/Market/MarketView.swift
@@ -14,6 +14,7 @@ struct MarketView: View {
     @State private var searchText: String = ""
     @State private var selectedCoinID: CoinID?
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @Environment(\.horizontalSizeClass) var hSizeClass
     
     @FetchRequest(
         fetchRequest: SearchRecordEntity.recent(),
@@ -55,11 +56,17 @@ struct MarketView: View {
             
         } detail: {
             if let selectedCoinID, let coin = store.coinMeta[selectedCoinID] {
-                CoinDetailView(coin: coin) {
-                    self.selectedCoinID = nil
-                }
-                    .id(coin.id)
+                VStack(spacing: 0) {
+                    HeaderView(
+                        heading: coin.koreanName,
+                        coinSymbol: coin.coinSymbol,
+                        showBackButton: hSizeClass == .regular ? false : true
+                    )
                     .toolbar(.hidden, for: .navigationBar)
+                    
+                    CoinDetailView(coin: coin)
+                    .id(coin.id)
+                }
                 
             } else {
                 CommonPlaceholderView(imageName: "logo", text: "조회할 코인을 선택하세요")

--- a/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct BookmarkView: View {
-    @Environment(\.dismiss) var dismiss
+    @Environment(\.horizontalSizeClass) var hSizeClass
     
     @StateObject var vm = BookmarkViewModel()
 
@@ -64,9 +64,7 @@ struct BookmarkView: View {
         ZStack(alignment: .top) {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    HeaderView(heading: "북마크 관리", showBackButton: true) {
-                        dismiss()
-                    }
+                    HeaderView(heading: "북마크 관리", showBackButton: hSizeClass == .regular ? false : true)
                     
                     // 북마크한 코인이 없을 시 브리핑 섹션 숨기기
                     if !bookmarks.isEmpty {
@@ -346,14 +344,4 @@ struct ExportReportView: View {
         }
         .padding(.top, 16)
     }
-}
-
-extension BookmarkView {
-    typealias CoinCache = NSCache<NSString, UIImage>
-    func exportBookmarkPNG(vm: BookmarkViewModel) async -> UIImage? {
-        let cache = CoinCache()
-        let symbols = vm.imageMap
-            return nil
-    }
-
 }

--- a/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/BookmarkView.swift
@@ -8,30 +8,28 @@
 import SwiftUI
 
 struct BookmarkView: View {
-    @Environment(\.horizontalSizeClass) var hSizeClass
-    
     @StateObject var vm = BookmarkViewModel()
-
+    
     @State private var selectedCategory: SortCategory? = nil
     @State private var nameOrder: SortOrder = .none
     @State private var priceOrder: SortOrder = .none
     @State private var volumeOrder: SortOrder = .none
-
+    
     @State private var showBulkInsertSheet = false
     @State private var isShowingShareSheet = false
     @State private var sharingItems: [Any] = []
     @State private var showingExportOptions = false
     @State private var showDeleteConfirm = false
     @State private var didCopy = false
-
+    
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \BookmarkEntity.timestamp, ascending: false)],
-            animation: .default
+        animation: .default
     )
     private var bookmarks: FetchedResults<BookmarkEntity>
-
+    
     private var isExportDisabled: Bool {
-           if bookmarks.isEmpty || vm.briefing == nil { return true }
+        if bookmarks.isEmpty || vm.briefing == nil { return true }
         switch vm.status {
         case .success:
             return false
@@ -39,7 +37,7 @@ struct BookmarkView: View {
             return true
         }
     }
-
+    
     // 정렬 데이터
     var sortedCoins: [BookmarkEntity] {
         switch selectedCategory{
@@ -54,29 +52,26 @@ struct BookmarkView: View {
             }
         case .volume:
             return Array(bookmarks)
-
+            
         case .none:
             return Array(bookmarks)
         }
     }
-
+    
     var body: some View {
-        ZStack(alignment: .top) {
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    HeaderView(heading: "북마크 관리", showBackButton: hSizeClass == .regular ? false : true)
-                    
-                    // 북마크한 코인이 없을 시 브리핑 섹션 숨기기
-                    if !bookmarks.isEmpty {
-                        HStack {
-                            SubheaderView(imageName: "sparkles", subheading: "아이코가 북마크를 분석했어요")
-                                .padding(.leading, -16)
-                            
-                            Spacer()
-                            
-                            RoundedButton(title: didCopy ? "복사 완료" : "내용 복사", imageName: didCopy ? "checkmark" : "document.on.document") {
-                                guard let dto = vm.briefing else { return }
-                                let text =
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                // 북마크한 코인이 없을 시 브리핑 섹션 숨기기
+                if !bookmarks.isEmpty {
+                    HStack {
+                        SubheaderView(imageName: "sparkles", subheading: "아이코가 북마크를 분석했어요")
+                            .padding(.leading, -16)
+                        
+                        Spacer()
+                        
+                        RoundedButton(title: didCopy ? "복사 완료" : "내용 복사", imageName: didCopy ? "checkmark" : "document.on.document") {
+                            guard let dto = vm.briefing else { return }
+                            let text =
                          """
                         [분석 결과]
                         \(dto.briefing)
@@ -84,121 +79,120 @@ struct BookmarkView: View {
                         [전략 제안]
                         \(dto.strategy)
                         """
-                                
-                                UIPasteboard.general.string = text
-                                didCopy = true
-                                
-                                Task {
-                                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                                    await MainActor.run { didCopy = false }
-                                }
-                            }
-                            .disabled(isExportDisabled)
-                            .opacity(isExportDisabled ? 0.6 : 1.0)
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.bottom, 16)
-                        
-                        Group {
-                            switch vm.status {
-                            case .loading:
-                                DefaultProgressView(status: .loading, message: "아이코가 분석중입니다") {
-                                    vm.cancelTask()
-                                }
-                            case .success:
-                                if let briefing = vm.briefing {
-                                    BriefingSectionView(briefing: briefing)
-                                }
-                            case .failure(let networkError):
-                                DefaultProgressView(status: .failure, message: networkError.localizedDescription) {
-                                    Task { await vm.loadBriefing(character: vm.userInvestmentType) }
-                                }
-                            case .cancel(let networkError):
-                                DefaultProgressView(status: .cancel, message: networkError.localizedDescription) {
-                                    Task { await vm.loadBriefing(character: vm.userInvestmentType) }
-                                }
+                            
+                            UIPasteboard.general.string = text
+                            didCopy = true
+                            
+                            Task {
+                                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                await MainActor.run { didCopy = false }
                             }
                         }
-                        .padding(20)
+                        .disabled(isExportDisabled)
+                        .opacity(isExportDisabled ? 0.6 : 1.0)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 16)
+                    
+                    Group {
+                        switch vm.status {
+                        case .loading:
+                            DefaultProgressView(status: .loading, message: "아이코가 분석중입니다") {
+                                vm.cancelTask()
+                            }
+                        case .success:
+                            if let briefing = vm.briefing {
+                                BriefingSectionView(briefing: briefing)
+                            }
+                        case .failure(let networkError):
+                            DefaultProgressView(status: .failure, message: networkError.localizedDescription) {
+                                Task { await vm.loadBriefing(character: vm.userInvestmentType) }
+                            }
+                        case .cancel(let networkError):
+                            DefaultProgressView(status: .cancel, message: networkError.localizedDescription) {
+                                Task { await vm.loadBriefing(character: vm.userInvestmentType) }
+                            }
+                        }
+                    }
+                    .padding(20)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .foregroundColor(.aiCoLabel)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color.aiCoBackgroundAccent)
+                            .overlay(RoundedRectangle(cornerRadius: 20)
+                                .strokeBorder(.accentGradient, lineWidth: 0.5))
+                    )
+                    .cornerRadius(20)
+                    .padding(.horizontal, 16)
+                    
+                    Text(String.aiGeneratedContentNotice)
+                        .font(.system(size: 11))
+                        .foregroundColor(.aiCoNeutral)
+                        .lineSpacing(5)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .foregroundColor(.aiCoLabel)
-                        .background(
-                            RoundedRectangle(cornerRadius: 20)
-                                .fill(Color.aiCoBackgroundAccent)
-                                .overlay(RoundedRectangle(cornerRadius: 20)
-                                    .strokeBorder(.accentGradient, lineWidth: 0.5))
-                        )
-                        .cornerRadius(20)
+                        .padding(.top, 10)
                         .padding(.horizontal, 16)
-                        
-                        Text(String.aiGeneratedContentNotice)
-                            .font(.system(size: 11))
-                            .foregroundColor(.aiCoNeutral)
-                            .lineSpacing(5)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.top, 10)
-                            .padding(.horizontal, 16)
-                            .padding(.bottom, 40)
+                        .padding(.bottom, 40)
+                }
+                
+                HStack {
+                    SubheaderView(subheading: "북마크한 코인")
+                    
+                    Spacer()
+                    
+                    RoundedButton(title: "전체 삭제", imageName: "trash") {
+                        showDeleteConfirm = true
+                    }
+                    .disabled(bookmarks.isEmpty)
+                    .opacity(bookmarks.isEmpty ? 0.6 : 1.0)
+                    .alert("전체 북마크 삭제", isPresented: $showDeleteConfirm) {
+                        Button("삭제", role: .destructive) {
+                            vm.deleteAllBookmarks()
+                        }
+                        Button("취소", role: .cancel) { }
+                    } message: {
+                        Text("모든 북마크를 삭제하시겠습니까?")
+                    }
+                }
+                .padding(.trailing, 16)
+                .padding(.bottom, 16)
+                
+                // 북마크한 코인이 없을 시 플레이스홀더 뷰 보여주기
+                if sortedCoins.isEmpty {
+                    CommonPlaceholderView(imageName: "placeholder-no-coin", text: "아직 북마크한 코인이 없어요\n북마크를 등록해 아이코의 AI리포트를 받아보세요")
+                        .padding(.vertical, 50)
+                }
+                
+                HStack(spacing: 16) {
+                    RoundedRectangleFillButton(title: "가져오기", imageName: "square.and.arrow.down", isHighlighted: .constant(sortedCoins.isEmpty)) {
+                        showBulkInsertSheet = true
                     }
                     
-                    HStack {
-                        SubheaderView(subheading: "북마크한 코인")
-                        
-                        Spacer()
-                        
-                        RoundedButton(title: "전체 삭제", imageName: "trash") {
-                            showDeleteConfirm = true
+                    // 북마크한 코인이 없을 시 내보내기 버튼 숨기기
+                    if !bookmarks.isEmpty {
+                        RoundedRectangleFillButton(title: "내보내기", imageName: "square.and.arrow.up", isHighlighted: .constant(false)) {
+                            guard !bookmarks.isEmpty else { return }
+                            showingExportOptions = true
+                            
                         }
                         .disabled(bookmarks.isEmpty)
                         .opacity(bookmarks.isEmpty ? 0.6 : 1.0)
-                        .alert("전체 북마크 삭제", isPresented: $showDeleteConfirm) {
-                            Button("삭제", role: .destructive) {
-                                vm.deleteAllBookmarks()
-                            }
-                            Button("취소", role: .cancel) { }
-                        } message: {
-                            Text("모든 북마크를 삭제하시겠습니까?")
-                        }
                     }
-                    .padding(.trailing, 16)
-                    .padding(.bottom, 16)
-                    
-                    // 북마크한 코인이 없을 시 플레이스홀더 뷰 보여주기
-                    if sortedCoins.isEmpty {
-                        CommonPlaceholderView(imageName: "placeholder-no-coin", text: "아직 북마크한 코인이 없어요\n북마크를 등록해 아이코의 AI리포트를 받아보세요")
-                            .padding(.vertical, 50)
-                    }
-                    
-                    HStack(spacing: 16) {
-                        RoundedRectangleFillButton(title: "가져오기", imageName: "square.and.arrow.down", isHighlighted: .constant(sortedCoins.isEmpty)) {
-                            showBulkInsertSheet = true
-                        }
-                        
-                        // 북마크한 코인이 없을 시 내보내기 버튼 숨기기
-                        if !bookmarks.isEmpty {
-                            RoundedRectangleFillButton(title: "내보내기", imageName: "square.and.arrow.up", isHighlighted: .constant(false)) {
-                                guard !bookmarks.isEmpty else { return }
-                                showingExportOptions = true
-                                
-                            }
-                            .disabled(bookmarks.isEmpty)
-                            .opacity(bookmarks.isEmpty ? 0.6 : 1.0)
-                        }
-                    }
-                    .padding(.horizontal, 16)
-                    
-                    if !sortedCoins.isEmpty {
-                        CoinListSectionView(
-                            sortedCoins: sortedCoins,
-                            selectedCategory: $selectedCategory,
-                            nameOrder: $nameOrder,
-                            priceOrder: $priceOrder,
-                            volumeOrder: $volumeOrder,
-                            imageProvider: { vm.imageProvider(for: $0) },
-                            onDelete: { vm.deleteBookmark($0) }
-                        )
-                        .padding(16)
-                    }
+                }
+                .padding(.horizontal, 16)
+                
+                if !sortedCoins.isEmpty {
+                    CoinListSectionView(
+                        sortedCoins: sortedCoins,
+                        selectedCategory: $selectedCategory,
+                        nameOrder: $nameOrder,
+                        priceOrder: $priceOrder,
+                        volumeOrder: $volumeOrder,
+                        imageProvider: { vm.imageProvider(for: $0) },
+                        onDelete: { vm.deleteBookmark($0) }
+                    )
+                    .padding(16)
                 }
             }
             .task {
@@ -228,7 +222,7 @@ struct BookmarkView: View {
                     }
                 }
             }
-
+            
             Button("PDF 내보내기") {
                 Task {
                     if let url = await vm.makeFullReportPDF(scale: 2.0) {
@@ -237,7 +231,7 @@ struct BookmarkView: View {
                     }
                 }
             }
-
+            
             Button("취소", role: .cancel) {}
         }
         .sheet(isPresented: $isShowingShareSheet) {
@@ -253,28 +247,28 @@ struct BookmarkView: View {
 
 struct BriefingSectionView: View {
     let briefing: PortfolioBriefingDTO
-
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("분석 결과")
                 .font(.system(size: 14))
                 .fontWeight(.semibold)
                 .foregroundColor(Color(.aiCoAccent))
-
+            
             briefing.briefing
                 .byCharWrapping
                 .highlightTextForNumbersOperator()
                 .font(.system(size: 14))
                 .fontWeight(.regular)
                 .lineSpacing(6)
-
+            
             Spacer(minLength: 20)
-
+            
             Text("전략 제안")
                 .font(.system(size: 14))
                 .fontWeight(.semibold)
                 .foregroundColor(Color(.aiCoAccent))
-
+            
             briefing.strategy
                 .byCharWrapping
                 .highlightTextForNumbersOperator()
@@ -292,14 +286,14 @@ struct BriefingSectionView: View {
 struct ActivityView: UIViewControllerRepresentable {
     let activityItems: [Any]
     let applicationActivities: [UIActivity]? = nil
-
+    
     func makeUIViewController(context: Context) -> UIActivityViewController {
         return UIActivityViewController(
             activityItems: activityItems,
             applicationActivities: applicationActivities
         )
     }
-
+    
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
@@ -308,12 +302,12 @@ struct ExportReportView: View {
     let dto: PortfolioBriefingDTO?
     let coins: [BookmarkEntity]
     let imageProvider: (String) -> UIImage?
-
+    
     @State private var selectedCategory: SortCategory? = .name
     @State private var nameOrder: SortOrder = .none
     @State private var priceOrder: SortOrder = .none
     @State private var volumeOrder: SortOrder = .none
-
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             // 브리핑
@@ -329,7 +323,7 @@ struct ExportReportView: View {
                     .cornerRadius(20)
                     .padding(.horizontal, 16)
             }
-
+            
             CoinListSectionView(
                 sortedCoins: coins,
                 selectedCategory: $selectedCategory,

--- a/AIProject/AIProject/Features/MyPage/View/CoinListSectionView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/CoinListSectionView.swift
@@ -38,7 +38,17 @@ struct CoinListSectionView: View {
 
             ForEach(sortedCoins, id: \.coinID) { coin in
                 NavigationLink {
-                    CoinDetailView(coin: Coin(id: coin.coinID, koreanName: coin.coinID))
+                    VStack(spacing: 0) {
+                        HeaderView(
+                            heading: coin.coinID,
+                            coinSymbol: coin.coinID,
+                            showBackButton: true
+                        )
+                        .toolbar(.hidden, for: .navigationBar)
+                        
+                        CoinDetailView(coin: Coin(id: coin.coinID, koreanName: coin.coinID))
+                        .id(coin.id)
+                    }
                 } label: {
                     CoinRowView(coin: coin, prefetched: imageProvider(coin.coinSymbol), onDelete: onDelete)
                 }

--- a/AIProject/AIProject/Features/MyPage/View/CoinListSectionView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/CoinListSectionView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct CoinListSectionView: View {
     let sortedCoins: [BookmarkEntity]
+    @Environment(CoinStore.self) var coinStore
+    
     @Binding var selectedCategory: SortCategory?
     @Binding var nameOrder: SortOrder
     @Binding var priceOrder: SortOrder
@@ -37,20 +39,22 @@ struct CoinListSectionView: View {
             .foregroundStyle(.aiCoLabel)
 
             ForEach(sortedCoins, id: \.coinID) { coin in
-                NavigationLink {
-                    VStack(spacing: 0) {
-                        HeaderView(
-                            heading: coin.coinID,
-                            coinSymbol: coin.coinID,
-                            showBackButton: true
-                        )
-                        .toolbar(.hidden, for: .navigationBar)
-                        
-                        CoinDetailView(coin: Coin(id: coin.coinID, koreanName: coin.coinID))
-                        .id(coin.id)
+                if let meta = coinStore.coins[coin.coinID] {
+                    NavigationLink {
+                        VStack(spacing: 0) {
+                            HeaderView(
+                                heading: meta.koreanName,
+                                coinSymbol: meta.coinSymbol,
+                                showBackButton: true
+                            )
+                            .toolbar(.hidden, for: .navigationBar)
+                            
+                            CoinDetailView(coin: meta)
+                                .id(coin.id)
+                        }
+                    } label: {
+                        CoinRowView(coin: coin, prefetched: imageProvider(coin.coinSymbol), onDelete: onDelete)
                     }
-                } label: {
-                    CoinRowView(coin: coin, prefetched: imageProvider(coin.coinSymbol), onDelete: onDelete)
                 }
             }
         }

--- a/AIProject/AIProject/Features/MyPage/View/Main/MyPageMenu.swift
+++ b/AIProject/AIProject/Features/MyPage/View/Main/MyPageMenu.swift
@@ -1,0 +1,32 @@
+//
+//  MyPageMenu.swift
+//  AIProject
+//
+//  Created by kangho lee on 8/30/25.
+//
+
+import Foundation
+
+enum MyPageMenu: String, Hashable, Identifiable {
+    case bookmark
+    case themeSet
+    case feedback
+    
+    var id: String { self.rawValue }
+    
+    var title: String {
+        switch self {
+        case .bookmark: return "북마크 관리"
+        case .themeSet: return "테마 변경"
+        case .feedback: return "이메일 문의"
+        }
+    }
+    
+    var icon: String {
+        switch self {
+        case .bookmark: return "bookmark"
+        case .themeSet: return "paintpalette"
+        case .feedback: return "at"
+        }
+    }
+}

--- a/AIProject/AIProject/Features/MyPage/View/Main/MyPageView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/Main/MyPageView.swift
@@ -10,143 +10,101 @@ import MessageUI
 
 struct MyPageView: View {
     @Environment(\.horizontalSizeClass) var hSizeClass
-    @Environment(\.dismiss) var dismiss
-    @State private var selection: String? = nil
+    @State private var selection: MyPageMenu? = nil
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var showMail = false
     @State private var showNoEmailView = false
-
+    
     var body: some View {
-        Group {
-            if hSizeClass == .regular {
-                // iPad
-                NavigationSplitView(columnVisibility: $columnVisibility) {
-                    sidebar
-                        .toolbar(removing: .sidebarToggle)
-                        .toolbar(.hidden, for: .navigationBar)
-                } detail: {
-                    NavigationStack {
-                        detailView
-                            .toolbar(.hidden, for: .navigationBar)
-                    }
-                }
-                .navigationSplitViewStyle(.balanced)
-            } else {
-                // iPhone
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            sidebar
+                .toolbar(removing: .sidebarToggle)
+                .toolbar(.hidden, for: .navigationBar)
+        } detail: {
+            if let selection {
                 NavigationStack {
-                    sidebar
+                    VStack(spacing: 0) {
+                        HeaderView(heading: selection.title, showBackButton: hSizeClass == .compact)
+                        switch selection {
+                        case .bookmark:
+                            BookmarkView()
+                        case .themeSet:
+                            ThemeView()
+                        case .feedback:
+                            NoEmailGuideView()
+                        }
+                    }
+                    .toolbar(.hidden, for: .navigationBar)
                 }
+            } else {
+                CommonPlaceholderView(imageName: "logo", text: "메뉴를 선택하세요")
             }
         }
-        .sheet(isPresented: $showMail) {
-            MailView()
-        }
-        .sheet(isPresented: $showNoEmailView) {
-            NoEmailGuideView(showClose: true)
-        }
+        .navigationSplitViewStyle(.balanced)
     }
-
+    
     // MARK: - Sidebar
     private var sidebar: some View {
         VStack {
             HeaderView(heading: "마이페이지")
-
-            VStack(spacing: 16) {
-                Group {
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("개인화 설정")
-                            .fontWeight(.semibold)
-
-                        VStack(spacing: 16) {
-                            menuButton("bookmark", title: "북마크 관리", imageName: "bookmark")
-                            menuButton("theme", title: "테마 변경", imageName: "paintpalette")
-                        }
-                    }
-
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("기타 설정")
-                            .fontWeight(.semibold)
-
-                        VStack(spacing: 16) {
-                            Button {
-                                if MFMailComposeViewController.canSendMail() {
-                                    showMail = true
-                                } else {
-                                    if hSizeClass == .regular {
-                                        selection = "contact"
-                                    } else {
-                                        showNoEmailView = true
-                                    }
+            
+            List(selection: $selection) {
+                VStack {
+                    Section {
+                        ForEach([MyPageMenu.bookmark, .themeSet]) { menu in
+                            MyPageMenuRow(title: menu.title, imageName: menu.icon)
+                                .contentShape(.rect)
+                                .onTapGesture {
+                                    selection = menu
                                 }
-                            } label: {
-                                MyPageMenuRow(title: "문의하기", imageName: "at")
-                            }
                         }
+                        .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                        .listRowSpacing(16)
+                    } header: {
+                        HStack {
+                            Text("개인화 설정")
+                                .fontWeight(.semibold)
+                            Spacer()
+                        }
+                        .padding(.bottom, 16)
                     }
                 }
-                .font(.system(size: 15, weight: .regular))
-                .foregroundStyle(.aiCoLabel)
                 .padding(20)
                 .background(
                     RoundedRectangle(cornerRadius: 20)
                         .fill(.aiCoBackground)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 20)
                         .strokeBorder(.defaultGradient, lineWidth: 0.5)
                 )
+                
+                VStack {
+                    Section {
+                        ForEach([MyPageMenu.feedback]) { menu in
+                            MyPageMenuRow(title: menu.title, imageName: menu.icon)
+                                .contentShape(.rect)
+                                .onTapGesture {
+                                    selection = menu
+                                }
+                        }
+                        .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                        .listRowSpacing(16)
+                    } header: {
+                        HStack {
+                            Text("개인화 설정")
+                                .fontWeight(.semibold)
+                            Spacer()
+                        }
+                        .padding(.bottom, 16)
+                    }
+                }
+                .padding(20)
+                .background(
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(.aiCoBackground)
+                        .strokeBorder(.defaultGradient, lineWidth: 0.5)
+                )
+                .listRowSeparator(.hidden)
             }
-            .padding(.horizontal, 16)
-
-            Spacer()
-        }
-    }
-
-    // MARK: - Detail View (iPad)
-    @ViewBuilder
-    private var detailView: some View {
-        switch selection {
-        case "bookmark":
-            BookmarkView()
-        case "theme":
-            ThemeView()
-        case "contact":
-            NoEmailGuideView()
-        default:
-            CommonPlaceholderView(imageName: "logo", text: "메뉴를 선택하세요")
-        }
-    }
-
-    // MARK: - 메뉴 버튼 (iPad는 selection 변경, iPhone은 NavigationLink)
-    @ViewBuilder
-    private func menuButton(_ tag: String, title: String, imageName: String) -> some View {
-        if hSizeClass == .regular {
-            // ipad
-            Button {
-                selection = tag
-            } label: {
-                MyPageMenuRow(title: title, imageName: imageName)
-            }
-        } else {
-            // iPhone
-            NavigationLink {
-                destination(for: tag)
-            } label: {
-                MyPageMenuRow(title: title, imageName: imageName)
-            }
-        }
-    }
-
-    // MARK: - NavigationLink 목적지
-    @ViewBuilder
-    private func destination(for tag: String) -> some View {
-        switch tag {
-        case "bookmark":
-            BookmarkView()
-        case "theme":
-            ThemeView()
-        default:
-            EmptyView()
+            .listStyle(.plain)
         }
     }
 }

--- a/AIProject/AIProject/Features/MyPage/View/Theme/ThemeView.swift
+++ b/AIProject/AIProject/Features/MyPage/View/Theme/ThemeView.swift
@@ -10,17 +10,11 @@ import SwiftUI
 /// 사용자가 테마를 선택할 수 있는 설정 뷰
 struct ThemeView: View {
     @EnvironmentObject var themeManager: ThemeManager
-    @Environment(\.dismiss) var dismiss
     
     var body: some View {
-        ZStack(alignment: .top) {
+        VStack {
             ScrollView {
                 VStack(spacing: 0) {
-                    HeaderView(heading: "테마 변경", showBackButton: true) {
-                        dismiss()
-                        print("Back")
-                    }
-                    
                     SubheaderView(subheading: "차트 색상 변경")
                         .padding(.bottom, 16)
                     


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- headerview는 파라미터로 받은 것에 대해서만 판단하게 만듬
- coinDetailView에서 headerview를 분리
- coinDetail을 사용하는 Bookmark / Market / Dashboard에서 sizeclass로 판단하여 headerview에 넘겨줌
- 코인 헤더 쪽에 썸네일 추가하였습니다.
- coinStore를 만들고 environment로 만들어서 coin meta 정보(id/symbol/koreanName)을 전역에서 coin-id만으로 가져올 수 있게 개선하였습니다.
- MyPageView iPad / iOS 분기되었던 코드를 NavigationSpliView하나로 합쳤습니다.
  - List(selection)을 이용해야 하면 iPad/iOS 분기처리할 필요없습니다. detail에는 NavigationStack을 이용해야 합니다.
  - MyPage menu를 enum으로 만들어 가독성 및 유지보수 개선하였습니다.
- bookmark 쪽 정보가 제대로 나오지 않는 문제 해결하였습니다.

## 예상되는 문제
- 희재님이 기존에 작업하신 safeArea 부분
- 다를 뷰는 header뷰를 가지고 있는데 coinDetail만 안 가지고 있어서 통일성이 좀 떨어짐

### 스크린샷 (선택)
<table>
<tr>
<th></th><th>iPad</th><th>iOS</th>
</tr>

<tr>
<td>Dashboard</td>
<td>
<img width="1488" height="2266" alt="IMG_0057" src="https://github.com/user-attachments/assets/c540127e-ca6e-4fcf-a1f5-a1b1ccc9bd93" />
</td>
<td>
<img width="1125" height="2436" alt="IMG_6590" src="https://github.com/user-attachments/assets/154e37e2-8b9d-4f49-a7dc-21f21f127e4b" />
</td>

</tr>

<tr>
<td>Market</td>
<td>
<img width="1488" height="2266" alt="IMG_0058" src="https://github.com/user-attachments/assets/b39218ad-4901-4663-be30-bcf17611336e" />
</td>
<td>
<img width="1125" height="2436" alt="IMG_6591" src="https://github.com/user-attachments/assets/40abb68b-65b2-4094-b06b-1e5636dccdc8" />
</td>
</tr>

<tr>
<td>Bookmark</td>
<td>
<img width="1488" height="2266" alt="IMG_0060" src="https://github.com/user-attachments/assets/56ee57a3-39b4-4dbc-aac6-9fcf7311c809" />
</td>
<td>
<img width="1125" height="2436" alt="IMG_6592" src="https://github.com/user-attachments/assets/eda8b467-607f-4456-9632-751eb302b107" />
</td>
</tr>

</table>
## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
