### PR TITLE
fix: 챗봇 isPortrait 로직 수정

### DIFF
--- a/AIProject/AIProject/Features/ChatBot/View/ChatBotView.swift
+++ b/AIProject/AIProject/Features/ChatBot/View/ChatBotView.swift
@@ -54,11 +54,11 @@ struct ChatBotView: View {
                 GeometryReader { proxy in
                     Color.clear
                         .onAppear {
-                            isPortrait = proxy.size.height < proxy.size.width
+                            isPortrait = !UIDevice.current.orientation.isPortrait
                             isPad = hSizeClass == .regular && vSizeClass == .regular
                         }
                         .onChange(of: proxy.size) {
-                            isPortrait = proxy.size.height < proxy.size.width
+                            isPortrait = !UIDevice.current.orientation.isPortrait
                             isPad = hSizeClass == .regular && vSizeClass == .regular
                         }
                 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>

- #484 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 

- 아이패드 회전 로직 변경

기존 코드에서 키보드가 올라올시에 `height`가 `width` 보다 작아지는 문제가 발생했습니다.

```swift
isPortrait = proxy.size.height < proxy.size.width
```

아래와 같은 코드로 직접 회전을 판단할 수 있도록 변경했습니다.

```swift
isPortrait = !UIDevice.current.orientation.isPortrait
```

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
