### PR TITLE
코인 추천 테스트 호출 변경

### DIFF
--- a/AIProject/AIProjectTests/RecommendCoinViewModelTests.swift
+++ b/AIProject/AIProjectTests/RecommendCoinViewModelTests.swift
@@ -63,6 +63,7 @@ final class RecommendCoinViewModelTests: XCTestCase {
     }
 
     func test_taskCancelsProperly() async {
+        sut.loadRecommendCoin()
         await sut.cancelTask()
 
         await MainActor.run {
@@ -76,11 +77,10 @@ final class RecommendCoinViewModelTests: XCTestCase {
     }
 
     func test_taskCompletesSuccessfully() async {
+        sut.loadRecommendCoin()
         await sut.task?.value
 
         await MainActor.run {
-            XCTAssertTrue(sut.recommendCoins.count == 5)
-
             guard case .success = sut.status else {
                 XCTFail("Expected .success, But got \(sut.status)")
                 return
@@ -89,6 +89,7 @@ final class RecommendCoinViewModelTests: XCTestCase {
     }
 
     func test_whenErrorOccurs_errorIsHandled() async {
+        sutWithError.loadRecommendCoin()
         await sutWithError.task?.value
 
         await MainActor.run {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

코인 추천 테스트 오류를 확인해봤더니 `loadRecommendCoin()` 을 이제 생성자에서 호출하지 않더라구요!
직접 테스트 메소드에서 호출하도록 변경했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
