### PR TITLE
차트 - 신규 상장 코인 판별 및 도메인/스크롤 보정 (배지 포함)

### DIFF
--- a/AIProject/iCo/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/iCo/Features/CoinDetail/View/ChartView.swift
@@ -21,12 +21,16 @@ struct ChartView: View {
     /// 시스템 앱 상태(active/inactive/background) 변화를 View에 전달하는 환경값
     @Environment(\.scenePhase) private var scenePhase
 
+    var onNewlyListedChange: (Bool) -> Void = { _ in }
+    
     // MARK: - Init
     init(
         coin: Coin,
         priceService: any CoinPriceProvider = UpbitPriceService(),
-        tickerAPI: UpBitAPIService = UpBitAPIService()
+        tickerAPI: UpBitAPIService = UpBitAPIService(),
+        onNewlyListedChange: @escaping (Bool) -> Void = { _ in }
     ) {
+        self.onNewlyListedChange = onNewlyListedChange
         _viewModel = StateObject(
             wrappedValue: ChartViewModel(
                 coin: coin,
@@ -69,11 +73,15 @@ struct ChartView: View {
                 .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
         .onAppear {
+            onNewlyListedChange(viewModel.isNewlyListed)
             viewModel.checkBookmark()
             viewModel.retry()
         }
         .onDisappear {
             viewModel.stopUpdating()
+        }
+        .onChange(of: viewModel.isNewlyListed) { _, newValue in
+            onNewlyListedChange(newValue)
         }
         .onChange(of: scenePhase, initial: false) { _, newPhase in
             switch newPhase {

--- a/AIProject/iCo/Features/CoinDetail/View/CoinDetailView.swift
+++ b/AIProject/iCo/Features/CoinDetail/View/CoinDetailView.swift
@@ -25,8 +25,11 @@ struct CoinDetailView: View {
     
     let coin: Coin
     
-    init(coin: Coin) {
+    var onNewlyListedChange: (Bool) -> Void = { _ in }
+    
+    init(coin: Coin, onNewlyListedChange: @escaping (Bool) -> Void = { _ in }) {
         self.coin = coin
+        self.onNewlyListedChange = onNewlyListedChange
         _reportViewModel = StateObject(wrappedValue: ReportViewModel(coin: coin))
     }
     
@@ -86,7 +89,7 @@ extension CoinDetailView {
     @ViewBuilder
     fileprivate func content(containerHeight: CGFloat) -> some View {
         if hSizeClass == .regular {
-            ChartView(coin: coin)
+            ChartView(coin: coin, onNewlyListedChange: onNewlyListedChange)
                 .frame(height: containerHeight * Layout.regularChartRatio)
             
             ReportView(viewModel: reportViewModel)
@@ -94,7 +97,7 @@ extension CoinDetailView {
         } else {
             switch selectedTab {
             case .chart:
-                ChartView(coin: coin)
+                ChartView(coin: coin, onNewlyListedChange: onNewlyListedChange)
                     .frame(height: containerHeight * Layout.compactChartRatio)
             case .report:
                 ReportView(viewModel: reportViewModel)

--- a/AIProject/iCo/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/iCo/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -420,7 +420,12 @@ extension ChartViewModel {
     ///   - data: 시각화할 가격 데이터 배열
     /// - Returns: 마지막 데이터 시점 +5분
     func scrollToTime(for data: [CoinPrice]) -> Date {
-        data.last?.date.addingTimeInterval(60 * 5) ?? Date()
+        guard let last = data.last?.date,
+              let first = data.first?.date else {
+            return Date()
+        }
+        
+        return (last.timeIntervalSince(first) < twentyFourHours) ? last : last.addingTimeInterval(60 * 5)
     }
 }
 

--- a/AIProject/iCo/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/iCo/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -328,8 +328,16 @@ final class ChartViewModel: ObservableObject {
             /// 신규 상장 여부 재판단
             if let first = prices.first?.date, let last = prices.last?.date {
                 let span = last.timeIntervalSince(first)
-                isNewlyListed = span < twentyFourHours - 60
+                
+                // 24h 분봉(1440개) 이상이면 초 경계 오차와 무관하게 신규 상장이 아닌 경우로 간주 (오탐 방지)
+                if prices.count >= 24 * 60 {
+                    isNewlyListed = false
+                } else {
+                    // 시간폭 기준: 24h보다 짧으면 신규로 판단 (1분 여유)
+                    isNewlyListed = span < twentyFourHours - 60
+                }
             } else {
+                // 데이터가 없으면 신규 취급
                 isNewlyListed = true
             }
             

--- a/AIProject/iCo/Features/Market/MarketView.swift
+++ b/AIProject/iCo/Features/Market/MarketView.swift
@@ -64,7 +64,7 @@ struct MarketView: View {
                             heading: coin.koreanName,
                             coinSymbol: coin.coinSymbol,
                             showBackButton: hSizeClass == .regular ? false : true,
-                            isNewlyListed: isNewlyListed
+                            showNewBadge: isNewlyListed
                         )
                         .toolbar(.hidden, for: .navigationBar)
                         

--- a/AIProject/iCo/Features/Market/MarketView.swift
+++ b/AIProject/iCo/Features/Market/MarketView.swift
@@ -22,6 +22,8 @@ struct MarketView: View {
     )
     private var records: FetchedResults<SearchRecordEntity>
     
+    @State private var isNewlyListed: Bool = false
+    
     init(coinService: UpBitAPIService, tickerService: RealTimeTickerProvider) {
         store = MarketStore(coinService: coinService, tickerService: tickerService)
     }
@@ -61,13 +63,21 @@ struct MarketView: View {
                         HeaderView(
                             heading: coin.koreanName,
                             coinSymbol: coin.coinSymbol,
-                            showBackButton: hSizeClass == .regular ? false : true
+                            showBackButton: hSizeClass == .regular ? false : true,
+                            isNewlyListed: isNewlyListed
                         )
                         .toolbar(.hidden, for: .navigationBar)
                         
-                        CoinDetailView(coin: coin)
-                            .id(coin.id)
+                        CoinDetailView(coin: coin) { isNew in
+                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
+                                isNewlyListed = isNew
+                            }
+                        }
+                        .id(coin.id)
                     }
+                }
+                .onChange(of: selectedCoinID) { _, _ in
+                    isNewlyListed = false
                 }
             } else {
                 CommonPlaceholderView(imageName: "logo", text: "조회할 코인을 선택하세요")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #546 

## 📝 작업 내용

- **로직: 상장 코인 빈 공간 스크롤 문제를 해결하기 위해 신규 상장 코인 판별 로직 추가**
  - `ChartViewModel`에 `isNewlyListed` 플래그 추가
  - `prices.count >= 1440(=24h)` 이면 무조건 `false` 
  - 최초 로드(`loadPrices`)와 증분 갱신(`refreshLatestCandles`) 후 매번 재평가
- **UI: 신규 상장 코인인 경우 기존의 24시간 도메인/스크롤 대신 보유하고 있는 데이터 구간만 보여주도록 수정**
  - `xAxisDomain(for:)`
  신규 상장(`true`): 데이터 있는 구간만
  신규 상장이 아닌 경우(`false`): 기존 동작 유지 (`now-24h`)
- **공통 헤더뷰에 신규 상장 로직 연동**
  - `HeaderView`: `isNewlyListed` 파라미터 추가
  - `ChartView`: `onNewlyListedChange` 콜백, `isNewlyListed` 변화 부모로 전파
  - `CoinDetailView`: 콜백을 받아 `ChartView`로 전달
  - `MarketView`: 배지 상태 보관 후 `HeaderView`에 주입, 코인 전환시 초기화

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 신규 상장 케이스
  - 24h 미만 데이터
  - X축이 보유하고 있는 데이터 구간만 보임
  - 스크롤도 데이터 범위 밖으로 안 나감
- 비신규(충분한 데이터) 케이스
  - X축이 최근 기준 24h 구간이 보임
  - 스크롤 동작 기존과 동일