### PR TITLE
[Hotfix] 신규 상장 로직 재추가 & 대시보드/북마크에도 신규 상장 판단 연동

### DIFF
--- a/AIProject/iCo/Features/CoinDetail/View/ChartView.swift
+++ b/AIProject/iCo/Features/CoinDetail/View/ChartView.swift
@@ -73,14 +73,14 @@ struct ChartView: View {
                 .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
         .onAppear {
-            onNewlyListedChange(viewModel.isNewlyListed)
+            onNewlyListedChange(viewModel.showNewBadge)
             viewModel.checkBookmark()
             viewModel.retry()
         }
         .onDisappear {
             viewModel.stopUpdating()
         }
-        .onChange(of: viewModel.isNewlyListed) { _, newValue in
+        .onChange(of: viewModel.showNewBadge) { _, newValue in
             onNewlyListedChange(newValue)
         }
         .onChange(of: scenePhase, initial: false) { _, newPhase in

--- a/AIProject/iCo/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/iCo/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -202,7 +202,14 @@ final class ChartViewModel: ObservableObject {
             /// 신규 상장 여부 계산 (보유 분봉 범위가 24h 미만이면 true)
             if let first = self.prices.first?.date, let last = self.prices.last?.date {
                 let span = last.timeIntervalSince(first)
-                self.isNewlyListed = span < twentyFourHours - 60  // 1분 여유
+                
+                // 24h 분봉(1440개) 이상이면 초 경계 오차와 무관하게 신규 상장이 아닌 경우로 간주 (오탐 방지)
+                if self.prices.count >= 24 * 60 {
+                    self.showNewBadge = false
+                } else {
+                    // 시간폭 기준: 24h보다 짧으면 신규로 판단 (1분 여유)
+                    self.showNewBadge = span < twentyFourHours - 60
+                }
             } else { // prices가 비어있을 때 (상장 직후)
                 self.isNewlyListed = true
             }

--- a/AIProject/iCo/Features/CoinDetail/ViewModel/ChartViewModel.swift
+++ b/AIProject/iCo/Features/CoinDetail/ViewModel/ChartViewModel.swift
@@ -38,7 +38,7 @@ final class ChartViewModel: ObservableObject {
     /// 취소/재시도 버튼을 실제 동작(네트워크 취소, 주기 루프 중단/재개)에 연결하는 상태 허브 (공용 컴포넌트 DefaultProgressView/StatusSwitch 연동)
     @Published private(set) var status: ResponseStatus = .loading
     /// 신규 상장 판별 플래그
-    @Published private(set) var isNewlyListed: Bool = false
+    @Published private(set) var showNewBadge: Bool = false
     
     /// 신규 상장 판별 위한 24시간 상수
     private let twentyFourHours: TimeInterval = 24 * 60 * 60
@@ -211,7 +211,7 @@ final class ChartViewModel: ObservableObject {
                     self.showNewBadge = span < twentyFourHours - 60
                 }
             } else { // prices가 비어있을 때 (상장 직후)
-                self.isNewlyListed = true
+                self.showNewBadge = true
             }
             
             if let ticker = ticker {
@@ -338,14 +338,14 @@ final class ChartViewModel: ObservableObject {
                 
                 // 24h 분봉(1440개) 이상이면 초 경계 오차와 무관하게 신규 상장이 아닌 경우로 간주 (오탐 방지)
                 if prices.count >= 24 * 60 {
-                    isNewlyListed = false
+                    showNewBadge = false
                 } else {
                     // 시간폭 기준: 24h보다 짧으면 신규로 판단 (1분 여유)
-                    isNewlyListed = span < twentyFourHours - 60
+                    showNewBadge = span < twentyFourHours - 60
                 }
             } else {
                 // 데이터가 없으면 신규 취급
-                isNewlyListed = true
+                showNewBadge = true
             }
             
             /// 헤더 동기 갱신 — UI 상태 변화 없음 (Progress View 없음)

--- a/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
@@ -43,6 +43,8 @@ struct CoinCarouselView: View {
         wrappedCoins.flatMap { $0.map { $0 }}
     }
     
+    @State private var showNewBadge = false
+    
     var body: some View {
         /// 화면의 가로 크기에 따라 카드 갯수를 관리하는 computed property
         var numberOfColumn: Int { hSizeClass == .regular ? 2 : 1 }
@@ -121,7 +123,8 @@ struct CoinCarouselView: View {
                         heading: coin.name,
                         topPadding: 20,
                         coinSymbol: coin.id,
-                        showBackButton: false
+                        showBackButton: false,
+                        showNewBadge: showNewBadge
                     )
                     .toolbar(.hidden, for: .navigationBar)
                     
@@ -132,7 +135,9 @@ struct CoinCarouselView: View {
                     .padding()
                 }
                 
-                CoinDetailView(coin: Coin(id: "KRW-" + coin.id, koreanName: coin.name, imageURL: coin.imageURL))
+                CoinDetailView(coin: Coin(id: "KRW-" + coin.id, koreanName: coin.name, imageURL: coin.imageURL))  { isNew in
+                    showNewBadge = isNew
+                }
             }
             .background(.background)
         }

--- a/AIProject/iCo/Features/Market/MarketView.swift
+++ b/AIProject/iCo/Features/Market/MarketView.swift
@@ -22,7 +22,7 @@ struct MarketView: View {
     )
     private var records: FetchedResults<SearchRecordEntity>
     
-    @State private var isNewlyListed: Bool = false
+    @State private var showNewBadge: Bool = false
     
     init(coinService: UpBitAPIService, tickerService: RealTimeTickerProvider) {
         store = MarketStore(coinService: coinService, tickerService: tickerService)
@@ -64,20 +64,18 @@ struct MarketView: View {
                             heading: coin.koreanName,
                             coinSymbol: coin.coinSymbol,
                             showBackButton: hSizeClass == .regular ? false : true,
-                            showNewBadge: isNewlyListed
+                            showNewBadge: showNewBadge
                         )
                         .toolbar(.hidden, for: .navigationBar)
                         
                         CoinDetailView(coin: coin) { isNew in
-                            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
-                                isNewlyListed = isNew
-                            }
+                            showNewBadge = isNew
                         }
                         .id(coin.id)
                     }
                 }
                 .onChange(of: selectedCoinID) { _, _ in
-                    isNewlyListed = false
+                    showNewBadge = false
                 }
             } else {
                 CommonPlaceholderView(imageName: "logo", text: "조회할 코인을 선택하세요")

--- a/AIProject/iCo/Features/MyPage/View/CoinListSectionView.swift
+++ b/AIProject/iCo/Features/MyPage/View/CoinListSectionView.swift
@@ -17,6 +17,8 @@ struct CoinListSectionView: View {
     @Binding var priceOrder: SortOrder
     @Binding var volumeOrder: SortOrder
 
+    @State private var showNewBadge = false
+    
     let imageProvider: (String) -> UIImage?
     let onDelete: (BookmarkEntity) -> Void
 
@@ -46,12 +48,15 @@ struct CoinListSectionView: View {
                             HeaderView(
                                 heading: meta.koreanName,
                                 coinSymbol: meta.coinSymbol,
-                                showBackButton: true
+                                showBackButton: true,
+                                showNewBadge: showNewBadge
                             )
                             .toolbar(.hidden, for: .navigationBar)
                             
-                            CoinDetailView(coin: meta)
-                                .id(coin.id)
+                            CoinDetailView(coin: meta) { isNew in
+                                showNewBadge = isNew
+                            }
+                            .id(coin.id)
                         }
                     } label: {
                         CoinRowView(coin: coin, prefetched: imageProvider(coin.coinSymbol), onDelete: onDelete)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

## 📝 작업 내용

- 신규 상장 로직 재추가 
- 대시보드/북마크에도 신규 상장 판단 연동

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
