### PR TITLE
챗봇 전송 취소 기능 구현

### DIFF
--- a/AIProject/iCo/Features/ChatBot/View/ChatInputView.swift
+++ b/AIProject/iCo/Features/ChatBot/View/ChatInputView.swift
@@ -24,7 +24,7 @@ struct ChatInputView: View {
             Button {
                 Task { await viewModel.sendMessage(message: viewModel.searchText) }
             } label: {
-                Image(systemName: "arrow.up")
+                Image(systemName: viewModel.isStreaming ? "square.fill" : "arrow.up")
                     .padding(10)
             }
             .frame(width: 30, height: 30)

--- a/AIProject/iCo/Features/ChatBot/View/ChatInputView.swift
+++ b/AIProject/iCo/Features/ChatBot/View/ChatInputView.swift
@@ -25,19 +25,20 @@ struct ChatInputView: View {
                 Task { await viewModel.sendMessage(message: viewModel.searchText) }
             } label: {
                 Image(systemName: viewModel.isStreaming ? "square.fill" : "arrow.up")
+                    .foregroundStyle(viewModel.isEditable && !viewModel.isStreaming ? .aiCoAccent : .aiCoNeutral)
                     .padding(10)
             }
             .frame(width: 30, height: 30)
             .background {
                 Circle()
-                    .fill(viewModel.isEditable ? .aiCoBackgroundAccent : .aiCoBackgroundWhite)
+                    .fill(viewModel.isEditable && !viewModel.isStreaming ? .aiCoBackgroundAccent : .aiCoBackgroundWhite)
             }
             .onChange(of: viewModel.isTapped) {
                 isFocused = false
             }
             .overlay {
                 Circle()
-                    .strokeBorder(viewModel.isEditable ? .accentGradient : .defaultGradient, lineWidth: 0.5)
+                    .strokeBorder(viewModel.isEditable && !viewModel.isStreaming ? .accentGradient : .defaultGradient, lineWidth: 0.5)
             }
             .disabled(!viewModel.isEditable)
         }

--- a/AIProject/iCo/Features/ChatBot/ViewModel/ChatBotViewModel.swift
+++ b/AIProject/iCo/Features/ChatBot/ViewModel/ChatBotViewModel.swift
@@ -35,6 +35,7 @@ final class ChatBotViewModel: ObservableObject {
 
     /// 서버와 통신하는 클라이언트입니다.
     private let chatBotClient: ChatBotClient
+    /// 메세지 전송 스트림 작업입니다.
     private var streamTask: Task<Void, Error>?
 
     init(chatBotClient: ChatBotClient = ChatBotClient()) {
@@ -42,6 +43,7 @@ final class ChatBotViewModel: ObservableObject {
     }
 
     /// 사용자가 입력한 메시지를 전송하고, 챗봇 응답 스트림을 관찰하여 UI에 반영합니다.
+    /// 만약 메세지가 이미 전송 중인 상태라면, 메세지 전송을 중단합니다.
     /// - Parameter content: 사용자가 전송하는 메세지 내용입니다.
     ///
     /// 이 메소드는 메인 쓰레드에서 실행됩니다.
@@ -121,6 +123,9 @@ final class ChatBotViewModel: ObservableObject {
         }
     }
     
+    /// 메세지 전송을 취소합니다.
+    ///
+    /// 이 메소드는 메인 쓰레드에서 실행됩니다.
     @MainActor
     private func cancelStream() {
         chatBotClient.continuation?.finish(throwing: NetworkError.taskCancelled)

--- a/AIProject/iCo/Features/ChatBot/ViewModel/ChatBotViewModel.swift
+++ b/AIProject/iCo/Features/ChatBot/ViewModel/ChatBotViewModel.swift
@@ -35,6 +35,7 @@ final class ChatBotViewModel: ObservableObject {
 
     /// 서버와 통신하는 클라이언트입니다.
     private let chatBotClient: ChatBotClient
+    private var streamTask: Task<Void, Error>?
 
     init(chatBotClient: ChatBotClient = ChatBotClient()) {
         self.chatBotClient = chatBotClient
@@ -46,35 +47,50 @@ final class ChatBotViewModel: ObservableObject {
     /// 이 메소드는 메인 쓰레드에서 실행됩니다.
     @MainActor
     func sendMessage(message: String) async {
-        searchText = ""
-        isStreaming = true
-
-        do {
+        if isStreaming {
+            cancelStream()
+        } else {
+            searchText = ""
+            isStreaming = true
             addMessage(with: message)
             isReceived = true
-            try await chatBotClient.connect(content: message)
-            try await observeStream()
+            
+            do {
+                try await chatBotClient.connect(content: message)
+                try await observeStream()
+            } catch let error as NetworkError {
+                switch error {
+                case .taskCancelled:
+                    chatBotClient.disconnect()
+                default:
+                    chatBotClient.disconnect()
+                    showStreamError()
+                }
+            } catch {
+                print("알 수 없는 에러 발생.")
+            }
+            
             isReceived = false
-        } catch {
-            await MainActor.run { showStreamError() }
+            isStreaming = false
         }
-
-        isStreaming = false
     }
 
     /// 챗봇 SSE 스트림을 관찰하여 토큰 단위로 UI에 메시지를 업데이트합니다.
     private func observeStream() async throws {
         guard let stream = chatBotClient.stream else { return }
 
-        for try await content in stream {
-            try await Task.sleep(for: .seconds(0.05))
-            await MainActor.run {
-                if let index = messages.lastIndex(where: { !$0.isUser }) {
-                    let message = messages[index]
-                    messages[index] = ChatMessage(content: message.content + content, isUser: false)
+        streamTask = Task {
+            for try await content in stream {
+                await MainActor.run {
+                    if let index = messages.lastIndex(where: { !$0.isUser }) {
+                        let message = messages[index]
+                        messages[index] = ChatMessage(content: message.content + content, isUser: false)
+                    }
                 }
             }
         }
+        
+        try await streamTask?.value
     }
 
     /// 사용자 메시지와 빈 챗봇 응답 메시지를 목록에 추가합니다.
@@ -92,7 +108,7 @@ final class ChatBotViewModel: ObservableObject {
     /// 이 메소드는 메인 쓰레드에서 실행됩니다.
     @MainActor
     private func checkValid() {
-        isEditable = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isStreaming
+        isEditable = !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isStreaming
     }
     
     /// SSE 데이터 전달 과정에서 에러가 발생했을 때 호출합니다.
@@ -103,5 +119,12 @@ final class ChatBotViewModel: ObservableObject {
         if let index = messages.lastIndex(where: { !$0.isUser }) {
             messages[index] = ChatMessage(content: "알 수 없는 에러가 발생했습니다.", isUser: false, isError: true)
         }
+    }
+    
+    @MainActor
+    private func cancelStream() {
+        chatBotClient.continuation?.finish(throwing: NetworkError.taskCancelled)
+        streamTask?.cancel()
+        streamTask = nil
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>

- #567 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 챗봇 전송 취소 기능 구현 

챗봇 전송 취소 작업을 구현했습니다. ChatGPT의 전송 취소를 참고했습니다!

---

전송 작업을 외부에서 끊을 수 있도록 하기 위해서 Task 객체에 담았습니다.

```swift
private var streamTask: Task<Void, Error>?

streamTask = Task { // SSE 스트림 메세지 전송 작업
    for try await content in stream {
        await MainActor.run {
            if let index = messages.lastIndex(where: { !$0.isUser }) {
                let message = messages[index]
                messages[index] = ChatMessage(content: message.content + content, isUser: false)
            }
        }
    }
}
```

전송 취소 메소드는 다음과 같습니다.

```swift
@MainActor
private func cancelStream() {
    chatBotClient.continuation?.finish(throwing: NetworkError.taskCancelled)
    streamTask?.cancel()
    streamTask = nil
}
```


### 스크린샷 (선택)

https://github.com/user-attachments/assets/90677bff-da7c-4870-808f-61bdaa070a1d


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 어색하거나 개선할 점이 있다면 말씀 부탁드립니다🙂
