### PR TITLE
[Test] 차트 X축/스크롤 테스트 정정

### DIFF
--- a/AIProject/iCoTests/ChartViewModel_Axis_Tests.swift
+++ b/AIProject/iCoTests/ChartViewModel_Axis_Tests.swift
@@ -11,37 +11,9 @@ import XCTest
 /// 차트 X축 도메인/초기 스크롤 시각 계산을 검증하는 테스트
 @MainActor
 final class ChartViewModel_Axis_Tests: XCTestCase {
-    /// 24h 미만(span < 24h)일 때:
-    /// - xAxisDomain == first...last
-    /// - scrollToTime == last
+    /// 장수 코인 시나리오(span ≥ 24h)에서 xAxisDomain과 scrollToTime이 최근 24h + 5분 버퍼로 계산되는지 검증
     func test_xAxisDomain_and_scrollToTime() {
         let base = Date()
-        let last = base.addingTimeInterval(600) // +10분
-        let data = [ makePrice(base, 100, 100),
-                     makePrice(last, 110, 111) ]
-
-        let vm = ChartViewModel(coin: .init(id: "KRW-SOL", koreanName: "솔라나"))
-        
-        let domain = vm.xAxisDomain(for: data)
-        
-        XCTAssertEqual(domain.lowerBound.timeIntervalSince1970,
-                       base.timeIntervalSince1970,
-                       accuracy: 1)
-        XCTAssertEqual(domain.upperBound.timeIntervalSince1970,
-                       last.timeIntervalSince1970,
-                       accuracy: 1)
-        XCTAssertEqual(vm.scrollToTime(for: data).timeIntervalSince1970,
-                       last.timeIntervalSince1970,
-                       accuracy: 1)
-    }
-    
-    /// 24h 이상(span ≥ 24h)일 때:
-    /// - xAxisDomain.lowerBound ≈ (now - 24h)
-    /// - xAxisDomain.upperBound == (last + 5m)
-    /// - scrollToTime == (last + 5m)
-    func test_xAxisDomain_and_scrollToTime_whenSpanIs24hOrMore() {
-        let base = Date()
-        // first = base, last = base + 24h + 10m  ⇒ span ≥ 24h
         let last = base.addingTimeInterval(24*60*60 + 10*60)
         let data = [
             makePrice(base, 100, 100),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #643 

## 📝 작업 내용

테스트 정리
- 로직 변경으로 불필요해진 `test_xAxisDomain_and_scrollToTime` 테스트 내용 삭제
- 기존 `test_xAxisDomain_and_scrollToTime_whenSpanIs24hOrMore` 내용을 `test_xAxisDomain_and_scrollToTime`로 이전


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
