### PR TITLE
[fix] 다이나믹 폰트 적용 후 Subheader 컨텐츠가 잘리는 이슈 개선

### DIFF
--- a/AIProject/iCo/Features/Base/SubheaderView.swift
+++ b/AIProject/iCo/Features/Base/SubheaderView.swift
@@ -40,6 +40,7 @@ struct SubheaderView: View {
                     .font(.ico15)
                     .foregroundStyle(fontColor)
                     .lineSpacing(6)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
@@ -233,6 +233,6 @@ extension CoinCarouselView {
 }
 
 #Preview {
-    RecommendCoinView()
+    RecommendCoinView(headerHeight: 140)
         .environmentObject(RecommendCoinViewModel())
 }

--- a/AIProject/iCo/Features/Dashboard/View/DashboardView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/DashboardView.swift
@@ -112,12 +112,6 @@ struct DashboardView: View {
     }
 }
 
-#Preview {
-    DashboardView()
-        .environmentObject(ThemeManager())
-        .environmentObject(RecommendCoinViewModel())
-}
-
 /// scrollOffset을 구하기 위한 PreferenceKey
 private struct ScrollOffsetPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat { .zero }
@@ -125,4 +119,10 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value += nextValue()
     }
+}
+
+#Preview {
+    DashboardView()
+        .environmentObject(ThemeManager())
+        .environmentObject(RecommendCoinViewModel())
 }

--- a/AIProject/iCo/Features/Dashboard/View/DashboardView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/DashboardView.swift
@@ -12,17 +12,25 @@ import SwiftUI
 /// 관심 코인 기반 추천, AI 브리핑으로 구성합니다.
 struct DashboardView: View {
     @Environment(\.horizontalSizeClass) var hSizeClass
+    @Environment(\.dynamicTypeSize) var typeSize
     
     @Namespace var coordinateSpaceName: Namespace.ID
     /// 스크롤의 위치를 저장하는 상태 변수
     @State var scrollOffset: CGFloat = 0
     /// 상단 여백을 저장하는 상태 변수: onAppear에서 실제 높이를 계산함
     @State var topInset: CGFloat = 0
+    @State var currentTypeSize: DynamicTypeSize = .medium
     
-    /// 배경색의 높이를 저장하는 계산 속성: 헤더의 높이 + 여백 + 카드의 높이 / 2 + 상단 여백
-    /// 배경이 카드의 중앙까지만 깔리게 해야 하는데 뷰가 여러 계층으로 나눠져있어서 각 컴포넌트의 높이를 계산해서 사용함
-    var gradientHeight: CGFloat {
-        CardConst.headerHeight + CardConst.headerContentSpacing + (CardConst.cardHeight / 2) + topInset
+    /// 다이나믹 폰트 적용 후 헤더 컨텐츠 크기가 커질 때
+    /// 헤더 사이즈를 유동적으로 조정하기 위해 사용하는 계산 속성
+    /// 헤더뷰와 배경 그래디언트 크기에도 영향을 주기 때문에
+    /// 여기에서 계산 후 헤더뷰에게 전파
+    var dynamicHeaderHeight: CGFloat {
+        switch typeSize {
+        case .xSmall, .small, .medium: CardConst.headerHeight
+        case .large, .xLarge, .xxLarge, .xxxLarge: CardConst.headerHeight * 1.1
+        default: CardConst.headerHeight * 1.4
+        }
     }
     
     var body: some View {
@@ -30,11 +38,17 @@ struct DashboardView: View {
         /// 쫀득한 효과를 더 드라마틱하게 보여주기 위해 스크롤 위치의 1.2배만큼 늘리기
         let extraHeight = max(0, -scrollOffset * 1.2)
         
+        /// 배경색의 높이를 저장하는 계산 속성: 헤더의 높이 + 여백 + 카드의 높이 / 2 + 상단 여백
+        /// 배경이 카드의 중앙까지만 깔리게 해야 하는데 뷰가 여러 계층으로 나눠져있어서 각 컴포넌트의 높이를 계산해서 사용함
+        var gradientHeight: CGFloat {
+            dynamicHeaderHeight + CardConst.headerContentSpacing + (CardConst.cardHeight / 2) + topInset
+        }
+        
         GeometryReader { outerProxy in
             NavigationStack {
                 ScrollView {
                     VStack {
-                        RecommendCoinView()
+                        RecommendCoinView(headerHeight: dynamicHeaderHeight)
                         AIBriefingView()
                     }
                     .padding(.top, topInset)

--- a/AIProject/iCo/Features/Dashboard/View/RecommendCoinView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/RecommendCoinView.swift
@@ -12,12 +12,14 @@ import SwiftUI
 /// 컨텐츠 뷰에 코인 추천 상태별로 알맞은 뷰를 뿌려줍니다.
 struct RecommendCoinView: View {
     @StateObject private var viewModel = RecommendCoinViewModel()
+    
+    let headerHeight: CGFloat
 
     var body: some View {
         ZStack(alignment: .top) {
             VStack(alignment: .center, spacing: CardConst.headerContentSpacing) {
                 RecommendHeaderView()
-                    .frame(height: CardConst.headerHeight)
+                    .frame(height: headerHeight)
                 
                 recommendContentView()
                     .frame(minHeight: CardConst.cardHeight)
@@ -70,7 +72,7 @@ struct RecommendCoinView: View {
 }
 
 #Preview {
-    RecommendCoinView()
+    RecommendCoinView(headerHeight: 140)
         .environmentObject(RecommendCoinViewModel())
 }
 

--- a/AIProject/iCo/Features/Dashboard/View/RecommendCoinView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/RecommendCoinView.swift
@@ -17,6 +17,7 @@ struct RecommendCoinView: View {
         ZStack(alignment: .top) {
             VStack(alignment: .center, spacing: CardConst.headerContentSpacing) {
                 RecommendHeaderView()
+                    .frame(height: CardConst.headerHeight)
                 
                 recommendContentView()
                     .frame(minHeight: CardConst.cardHeight)

--- a/AIProject/iCo/Features/Dashboard/View/RecommendHeaderView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/RecommendHeaderView.swift
@@ -19,14 +19,13 @@ struct RecommendHeaderView: View {
                 imageColor: .white,
                 fontColor: .white
             )
-            
-            Spacer()
         }
-        .frame(height: CardConst.headerHeight)
     }
 }
 
 #Preview() {
     RecommendCoinView()
         .environmentObject(RecommendCoinViewModel())
+        .environmentObject(ThemeManager())
+        .background(.black.opacity(0.2))
 }

--- a/AIProject/iCo/Features/Dashboard/View/RecommendHeaderView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/RecommendHeaderView.swift
@@ -24,7 +24,7 @@ struct RecommendHeaderView: View {
 }
 
 #Preview() {
-    RecommendCoinView()
+    RecommendCoinView(headerHeight: 140)
         .environmentObject(RecommendCoinViewModel())
         .environmentObject(ThemeManager())
         .background(.black.opacity(0.2))


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
> 

- #642 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
>

- 자잘한 리팩토링
- Subheader 컨텐츠에 fixedSize 설정
- typeSize에 따라 Dashboard 헤더 높이 보정

### 스크린샷 (선택)

좌 before, 우 after

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-28 at 11 33 24" src="https://github.com/user-attachments/assets/b6b30353-f14c-46e8-8516-ea3234de6d38" />
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-28 at 11 33 56" src="https://github.com/user-attachments/assets/a30b0862-00fe-4a10-9c11-a081d715d853" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

글이 말줄임표되는 이슈는 fixedSize로 없애고,
헤더와 카드 간의 간격이 좁아지는 이슈는 typeSize를 이용해 헤더 높이를 변경하는 방식으로 해결했는데
다른 해결 방법이 없는지 확신이 안서네요 ㅎㅎ

그라디언트 배경을 카드 크기의 반만 채워지게 디자인한 부분부터가 문제의 시작이었던 것 같으나
디자인적으로 다른 수를 찾을 수 없었다는 변명을 한 번 해봅니다 허허..