### PR TITLE
다이나믹 폰트 적용 시 생기는 대시보드 레이아웃 이슈 해결

### DIFF
--- a/AIProject/iCo/Domain/Model/Common/Prompt.swift
+++ b/AIProject/iCo/Domain/Model/Common/Prompt.swift
@@ -85,7 +85,7 @@ enum Prompt {
                 let summary: String
             }
             
-            커뮤니티 분위기(호재, 악재, 중립)와 그렇게 평가한 이유를 한글로 200자 이상으로 요약해 위 형식으로 작성해서 JSON으로 제공 (답변은 한글, 마크다운 금지, 출처 제외)
+            커뮤니티 분위기(호재, 악재, 중립)와 그렇게 평가한 이유를 한글로 200자 이상으로 요약해 위 InsightDTO로 디코딩 할 수 있도록 작성해서 JSON으로 제공 (답변은 한글, 종결 어미는 '-ㅂ니다', 마크다운 금지, 출처 제외)
             """
         case .generateBookmarkBriefing(let importance, let bookmarks):
             """

--- a/AIProject/iCo/Features/Dashboard/View/AIBriefingView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/AIBriefingView.swift
@@ -34,7 +34,7 @@ struct AIBriefingView: View {
             
             VStack(spacing: 16) {
                 if isPadLayout {
-                    HStack(spacing: 16) {
+                    HStack(alignment: .top, spacing: 16) {
                         briefingView
                         TopCoinListView()
                     }

--- a/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
@@ -184,6 +184,7 @@ struct CoinCarouselView: View {
                     }
                 )
             }
+            .scrollIndicators(.hidden)
             .presentationDetents([detent])
             
         }

--- a/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/CoinCarouselView.swift
@@ -139,50 +139,53 @@ struct CoinCarouselView: View {
             wrappedCoins.removeAll()
         }
         .sheet(item: $selectedCoin) { coin in
-            VStack(spacing: 30) {
-                CoinInfoView(recommendCoin: coin) {
-                    selectedCoin = nil
-                }
-                
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "sparkles")
-                            .font(.ico16B)
-                            .foregroundStyle(.iCoAccent)
-                        
-                        Text("아이코가 추천하는 이유")
-                            .font(.ico18B)
-                            .foregroundStyle(.iCoLabel)
+            ScrollView {
+                VStack(spacing: 30) {
+                    CoinInfoView(recommendCoin: coin) {
+                        selectedCoin = nil
                     }
                     
-                    Text(String.aiGeneratedContentNotice)
-                        .font(.ico13)
-                        .foregroundStyle(.iCoNeutral)
-                        .lineSpacing(6)
-                    
-                    Text(coin.comment.byCharWrapping)
-                        .font(.ico16)
-                        .lineSpacing(6)
-                        .foregroundStyle(.iCoLabel)
-                }
-                .fixedSize(horizontal: false, vertical: true)
-                
-                RoundedRectangleFillButton(title: "더 자세히 보러가기", imageName: "info.circle", isHighlighted: .constant(true)) {
-                    selectedCoin = nil
-                    showDetailCoin = coin
-                }
-            }
-            .padding(20)
-            .background(.background)
-            .background(
-                GeometryReader { geo in
-                    Color.clear
-                        .onAppear {
-                            measuredHeight = geo.size.height
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(spacing: 8) {
+                            Image(systemName: "sparkles")
+                                .font(.ico16B)
+                                .foregroundStyle(.iCoAccent)
+                            
+                            Text("아이코가 추천하는 이유")
+                                .font(.ico18B)
+                                .foregroundStyle(.iCoLabel)
                         }
+                        
+                        Text(String.aiGeneratedContentNotice)
+                            .font(.ico13)
+                            .foregroundStyle(.iCoNeutral)
+                            .lineSpacing(6)
+                        
+                        Text(coin.comment.byCharWrapping)
+                            .font(.ico16)
+                            .lineSpacing(6)
+                            .foregroundStyle(.iCoLabel)
+                    }
+                    .fixedSize(horizontal: false, vertical: true)
+                    
+                    RoundedRectangleFillButton(title: "더 자세히 보러가기", imageName: "info.circle", isHighlighted: .constant(true)) {
+                        selectedCoin = nil
+                        showDetailCoin = coin
+                    }
                 }
-            )
+                .padding(20)
+                .background(.background)
+                .background(
+                    GeometryReader { geo in
+                        Color.clear
+                            .onAppear {
+                                measuredHeight = geo.size.height
+                            }
+                    }
+                )
+            }
             .presentationDetents([detent])
+            
         }
         .onChange(of: selectedCoin) { _, newValue in
             updateTimerState()

--- a/AIProject/iCo/Features/Dashboard/View/FearGreedView.swift
+++ b/AIProject/iCo/Features/Dashboard/View/FearGreedView.swift
@@ -26,27 +26,43 @@ struct FearGreedView: View {
         case .xSmall, .small, .medium, .large:
             return baseWidth
         case .xLarge, .xxLarge, .xxxLarge:
-            return baseWidth * 0.9
+            return baseWidth * 1.2
         default:
-            return baseWidth * 0.7
+            return baseWidth * 1.4
         }
     }
     
     var body: some View {
         VStack {
-            HStack(alignment: .center, spacing: 0) {
-                headerSection
+            if typeSize >= .xLarge && hSizeClass == .compact {
+                VStack(alignment: .leading, spacing: 0) {
+                    headerSection
+                    
+                    if showFearGreedDescription {
+                        fearGreedDescription
+                            .opacity(!showFearGreedDescription ? 0 : 1)
+                            .animation(.snappy(duration: 0.3), value: showFearGreedDescription)
+                    }
+                    
+                    chartSection
+                        .padding(.top, 22)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                HStack(alignment: .center, spacing: 0) {
+                    headerSection
+
+                    Spacer()
+
+                    chartSection
+                }
                 
-                Spacer()
-                
-                chartSection
-                    .fixedSize(horizontal: true, vertical: false)
-            }
-            
-            if showFearGreedDescription {
-                fearGreedDescription
-                    .opacity(!showFearGreedDescription ? 0 : 1)
-                    .animation(.snappy(duration: 0.3), value: showFearGreedDescription)
+                if showFearGreedDescription {
+                    fearGreedDescription
+                        .opacity(!showFearGreedDescription ? 0 : 1)
+                        .animation(.snappy(duration: 0.3), value: showFearGreedDescription)
+                }
             }
         }
         .padding(.horizontal, 22)
@@ -57,7 +73,6 @@ struct FearGreedView: View {
             RoundedRectangle(cornerRadius: Self.cornerRadius)
                 .strokeBorder(.defaultGradient, lineWidth: 0.5)
         )
-        .animation(.snappy(duration: 0.2), value: showFearGreedDescription)
     }
     
     var headerSection: some View {
@@ -119,6 +134,7 @@ struct FearGreedView: View {
             .font(.ico12M)
             .foregroundStyle(.secondary)
         }
+        .fixedSize(horizontal: true, vertical: false)
     }
     
     var fearGreedDescription: some View {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) <#1377914257735421952>, <#1377914203255607316>
>
- close #681  

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 대시보드 양 옆 패딩이 사라지고 컨텐츠가 잘리는 현상
    - HStack 안에 `fixedSize(horizontal: true)`를 적용한 View가 두개였습니다. (공포탐욕지수 설명 버튼, 차트) 두가지 다 가로로 컨텐츠 만큼의 크기를 유지하려다보니 기기의 크기를 넘어가면서 레이아웃이 망가지는 것이 이유였습니다.
    - 다이나믹 타입이 xLarge 이상인 경우에는 차트를 아래쪽으로 배치해서 해결했습니다.
    - 기존에 공간을 위해 다이나믹 타입이 커질 때 차트 크기를 줄이고 있었는데, 차트가 아래로 내려가면서 여유 공간이 생겨 차트 크기를 키웠습니다.
- 추천 코인 첫번째 depth인 설명 보기 탭이 폰트 사이즈가 커지면 컨텐츠가 상하로 잘리는 현상
    - ScrollView 적용해서 해결했습니다. 

### 스크린샷 (선택)
<table>
<tr>
<th>전</th>
<th>후</th>
</tr>
<tr>
<td>
<img width="201" height="437" alt="Image" src="https://github.com/user-attachments/assets/c375b147-b7d9-4786-b26a-eac9c703a264" />
</td>
<td>
<img width="216" height="468" alt="Simulator Screenshot - iPhone 13 mini - 2025-11-20 at 14 54 58" src="https://github.com/user-attachments/assets/fb2d28bc-5b88-42c4-8549-52f101f18dc0" />
</td>
</tr>
<tr>
<td>
<img width="201" height="437" alt="Simulator Screenshot - iPhone 17 - 2025-11-20 at 13 55 49" src="https://github.com/user-attachments/assets/413f9d0c-23f9-4179-9cc7-9056a6644b9c" />
</td>
<td>
<img width="216" height="468" alt="Simulator Screenshot - iPhone 13 mini - 2025-11-20 at 15 18 38" src="https://github.com/user-attachments/assets/89e44d59-37c5-4ec1-ae96-2185f89a9098" />
</td>
</tr>
</table>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>
